### PR TITLE
fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,5 @@ dependencies = [
     "python-dotenv>=1.0", # load LLM_* config from a .env file
 ]
 
-[project.scripts]
-librarian = "main:main"
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build.targets.wheel]
-packages = ["librarian"]
+[tool.uv]
+package = false

--- a/uv.lock
+++ b/uv.lock
@@ -129,7 +129,7 @@ wheels = [
 [[package]]
 name = "librarian"
 version = "0.1.0"
-source = { editable = "." }
+source = { virtual = "." }
 dependencies = [
     { name = "bm25s" },
     { name = "pysbd" },


### PR DESCRIPTION
## What

The project is no longer installed as an editable package into the `uv` venv.

- Added `[tool.uv]` with `package = false` so that `uv sync` installs only the dependencies, not `librarian` itself.