### PR TITLE
address model's api with rejceted parameters

### DIFF
--- a/librarian/llm_client.py
+++ b/librarian/llm_client.py
@@ -65,6 +65,9 @@ class LLMClient:
         self.api_key = api_key or os.getenv("LLM_API_KEY", "EMPTY")
         self.model_name = model_name or os.getenv("LLM_MODEL")
 
+        # Optional sampling parameters this endpoint has rejected with a 400.
+        self._unsupported: set = set()
+
         print(f"LLMClient -> url={self.base_url} model={self.model_name}")
 
     def _url(self) -> str:
@@ -114,21 +117,29 @@ class LLMClient:
 
         Retries rate-limit (429), 5xx, and transient network errors with
         exponential backoff + jitter; 4xx client errors are not retried.
+
+        One exception: a 400 that names an optional sampling parameter (``error
+        .param``) makes us drop that parameter and retry immediately.
         """
-        payload = {
-            "model": self.model_name,
-            "messages": messages,
-            "temperature": temperature,
-        }
+        optional = {"temperature": temperature}
         if max_tokens is not None:
-            payload["max_tokens"] = max(1, int(max_tokens))
+            optional["max_tokens"] = int(max_tokens)
 
         last_exception = None
         for attempt in range(self.MAX_RETRIES):
+            payload = {
+                "model": self.model_name,
+                "messages": messages,
+                **{k: v for k, v in optional.items() if k not in self._unsupported},
+            }
             try:
                 response = requests.post(
                     self._url(), headers=self._headers(), json=payload, timeout=timeout
                 )
+                if response.status_code == 400:
+                    last_exception = Exception(f"400: {response.text[:200]}")
+                    if self._drop_rejected_param(response, optional):
+                        continue  # same request, minus the rejected parameter
                 if response.status_code == 429:
                     last_exception = Exception(f"429: {response.text[:200]}")
                     time.sleep(
@@ -158,6 +169,30 @@ class LLMClient:
         raise Exception(
             f"LLM API request failed after {self.MAX_RETRIES} retries: {last_exception}"
         )
+
+    def _drop_rejected_param(self, response: Any, optional: dict) -> bool:
+        """Given a 400 code, mark the parameter the endpoint complained about as
+        unsupported. Returns True if something was dropped and the request is
+        worth retrying, False to let the 400 surface to the caller."""
+        try:
+            error = (response.json() or {}).get("error") or {}
+        except ValueError:
+            return False
+
+        message = str(error.get("message") or "")
+        param = error.get("param")
+        if param not in optional:
+            param = next((k for k in optional if f"'{k}'" in message), None)
+
+        if param is None or param in self._unsupported:
+            return False
+
+        self._unsupported.add(param)
+        print(
+            f"LLMClient: {self.model_name} rejected '{param}' "
+            f"({message[:120]}); retrying without it"
+        )
+        return True
 
     @staticmethod
     def _backoff(attempt: int, retry_after: Optional[str] = None) -> float:


### PR DESCRIPTION
## Issue 

`LLMClient.chat_completion` always sent `temperature` and `max_tokens`, and the agent's call
sites pass explicit values for both — `temperature=0.3, max_tokens=8192` for query generation
(`librarian/agent.py:329`) and `temperature=self._filter_temperature, max_tokens=4096` for the
evidence filter (`librarian/agent.py:518`).

This is fine with `gpt-4o` model. Howwever, the GPT-5 family rejects both. 

Below is my proposed solution. Feel free to modify it or implement even better solution. 


## The fix

The LLMclient now follows one general rule: stop sending the rejceted parameter, and retry.

The endpoint already reports exactly which parameter it won't accept, in the standard
`error.param` field. No model-name matching and no per-provider table is needed.

Three small changes in `librarian/llm_client.py`:

1. **`self._unsupported` set**: parameters this endpoint has rejected, remembered per
   client instance.
2. **Self-filtering payload**: `temperature` and `max_tokens` live in an `optional`
   dict; each attempt rebuilds the payload omitting anything in `_unsupported`. Dropping a
   parameter means the server's own default applies.
3. **`_drop_rejected_param()`**: on a 400, read `error.param`; if it's an optional
   parameter we haven't already dropped, add it to the set, log one line, and return `True` so
   the loop retries immediately with no backoff. Anything else returns `False` and the 400
   surfaces as before.

## Note
- **`gpt-4o` and self-hosted vLLM are unaffected.** They accept both parameters, never return
  the 400, and so never trigger the downgrade.