### PR TITLE
[5/11] Fold paper metadata into Stage-2 BM25 (author/journal/year matchable)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -78,16 +78,22 @@ in your shell.
 > settings used in all experiments.
 
 On a terminal you'll see a live spinner reporting the current stage (`Searching Europe
-PMC`, `Fetching full text · 42/210`, `Judging paper relevance · 6/28 batches`, ...) so
-you can tell how far along a run is. When the output is piped/redirected the spinner is
-skipped and the agent prints plain `[Librarian]` log lines instead.
+PMC`, `Found 210 candidate paragraphs`, `Judging paragraph relevance · 6/8 batches`, ...)
+so you can tell how far along a run is. When the output is piped/redirected the spinner
+is skipped and the agent prints plain `[Librarian]` log lines instead.
 `LibrarianAgent.run()` accepts an `on_progress=callable` hook if you want to drive your
-own UI.
+own UI, and a `tracer=` hook (see [`tracing_port.py`](librarian/tracing_port.py)) if you
+want to wire span tracing into your own backend.
 
 ---
 
 ## 📰 News
 
+* **[2026.09.03]** Retrieval pipeline rework: paragraph-level pooling across
+  sub-queries, a single relevance judge (replacing the two concurrent
+  full-text/abstract judges), snippet-level citations, author affiliation,
+  uncapped per-paper evidence, and an optional `tracer=` span-tracing hook.
+  See [⚙️ Configuration](#️-configuration) — several knobs changed with it.
 * **[2026.07.31]** Preprint available on arXiv.
 * **[2026.07.30]** Initial release of the EMBL AI Librarian agent and retrieval pipeline.
 
@@ -124,6 +130,11 @@ suites we evaluate:
 | ProClaim-eval | Agreement w/ expert consensus | 0.75 | **0.80** |
 | Open-form LitQA2 | Accuracy | 70.3 (GPT-5.4 + web search) | **78.9** |
 | LAB-Bench | Macro accuracy (GPT-5.4) | 50.5 | **54.6** (+11.3 on SeqQA) |
+
+> **Note:** the numbers above are from the pipeline described in the paper (paper-level
+> pooling, two concurrent relevance judges, capped evidence). The retrieval pipeline has
+> since been reworked (see [📰 News](#-news)) and these numbers are pending
+> re-validation against the current single-judge, paragraph-pooled pipeline.
 
 Two comparisons matter and they answer different questions. Against **strong published
 baselines**, Librarian is more than **+16 Citation F1** on ScholarQA-Bench — but part of
@@ -170,42 +181,48 @@ Two conservative fallbacks guard the degenerate cases:
 </details>
 
 <details>
-<summary><b>Stage 2: Paper-level Retrieval + Paragraph BM25 Ranking</b></summary>
+<summary><b>Stage 2: Per-sub-query Retrieval + Paragraph BM25 Ranking</b></summary>
 
-Validated sub-queries run in parallel against the live Europe PMC search service, each
-returning up to P records (pool of at most M = N × P).
+Validated sub-queries run in parallel — one thread per sub-query, capped at the CPUs
+actually available (reading the container's cgroup CPU quota when present, so a large
+sub-query count can't oversubscribe a small container).
 
-Because complementary sub-queries often return the same paper, candidates are
-**deduplicated here, before any full text is fetched**, so a paper found by several
-sub-queries is fetched exactly once. Deduplication is hierarchical: PMID first, then DOI
-when a PMID is absent, then title — PMID alone is insufficient because Europe PMC also
-indexes preprints and some PMC content without one.
+Each sub-query searches the live Europe PMC service (up to `papers_per_subquery`
+records), and every returned paper is decomposed into paragraph records: its abstract,
+plus — for open-access papers — its full-text body paragraphs (JATS XML fetched by
+PMCID, `literature_search.py` + `jats.py`). Paragraphs longer than
+`max_paragraph_words` are split into overlapping word windows so a long paragraph
+can't out-rank a short one on length alone. Every record's BM25 document mixes in its
+section title/type and the paper's own metadata (title/authors/journal/year on the
+abstract, year only on body chunks, so a query naming an author or year still matches
+without letting metadata dominate every one of a paper's chunks) plus optional
+Snowball stemming (`LITERATURE_BM25_STEMMING=0` to disable).
 
-For each surviving open-access paper, Librarian fetches the JATS XML (cached by PMCID),
-extracts the body paragraphs and discards references and other front/back matter
-(`literature_search.py`, `jats.py`), then BM25-ranks those paragraphs against the
-original question — each paragraph concatenated with its section title and type. Every
-paper passes k paragraphs onward: always its abstract, plus the highest-ranked
-paragraphs when full text is available, keeping the top ~2300 words as a
-`full_text_excerpt`. Papers without full text contribute their abstract only.
+Each sub-query's paragraphs are BM25-ranked against *that sub-query's* text and the
+top `paragraphs_per_subquery` are kept. Because complementary sub-queries often surface
+the same or overlapping paragraphs, the per-sub-query pools are then merged: identical
+or overlapping selections from the same source paragraph are unioned into one record,
+so a paragraph relevant to several sub-queries costs the downstream judge budget once.
 
 </details>
 
 <details>
-<summary><b>Stage 3: Filter, Re-ranking & Evidence Extraction</b></summary>
+<summary><b>Stage 3: Single-pass Relevance Judge & Evidence Extraction</b></summary>
 
-Paragraphs are segmented into sentences with pySBD and each sentence is given a unique
-identifier. Two judges run concurrently: a full-text judge over papers that carry an
-excerpt (`prompts/relevance_filter_fulltext.md`) and an abstract triage over
-abstract-only candidates (`prompts/relevance_filter.md`). Each call returns an ordered
-list of sentence identifiers, which simultaneously filters irrelevant paragraphs,
-re-ranks the relevant ones, and extracts the supporting sentences that become each
-paper's `evidence_snippets`. Because the model emits short identifiers rather than
-regenerating text, it decodes far fewer tokens.
+The merged paragraph pool is segmented into sentences with pySBD, each given a stable
+identifier, and judged in batches of `paragraphs_per_judge_batch` paragraphs
+(`prompts/relevance_filter.md`). One LLM call returns an ordered list of sentence
+identifiers, which simultaneously filters irrelevant paragraphs, re-ranks the relevant
+ones, and extracts the supporting sentences. Cited sentences are grouped by paper into
+contiguous evidence spans (`evidence_snippets`) in reading order — a paper whose cited
+sentences aren't adjacent yields more than one span rather than one string silently
+splicing distant sentences together. There is no cap on evidence length per paper: the
+judge's own citation decision is the only filter.
 
-One last fallback: if both relevance filters reject every candidate, the unfiltered
-candidate pool is returned instead of an empty evidence set — trading precision for
-non-empty output.
+A malformed or truncated judge reply is not discarded outright: ids are salvaged from
+the raw text where possible, and an unparseable batch is split and retried (up to two
+levels) before giving up on it. Papers the judge never cites are dropped; there is no
+final `top_k` cap layered on top of the judge's own decision.
 
 </details>
 
@@ -216,7 +233,9 @@ The result is a list of passage dicts:
   "evidence_snippets": ["...cited sentence span...", ...],
   "paper_id": "12345678",
   "title": "...", "authors": "...", "journal": "...", "year": "2023",
-  "pmid": "12345678", "doi": "10.xxxx/...", "has_fulltext": True,
+  "pmid": "12345678", "doi": "10.xxxx/...", "epmcId": "...", "epmcSource": "MED",
+  "url": "https://europepmc.org/article/...", "affiliation": "...",
+  "has_fulltext": True,
 }
 ```
 
@@ -231,11 +250,18 @@ editing code:
 | Env var | Default | Meaning |
 |---|---|---|
 | `LITERATURE_MAX_QUERY_COUNT` | 7 | max sub-queries generated |
-| `LITERATURE_MAX_FULLTEXT_PAPERS` | 30 | full-text papers in the answer |
-| `LITERATURE_MAX_ABSTRACT_ONLY_PAPERS` | 30 | abstract-only papers in the answer |
-| `LITERATURE_FULL_TEXT_TARGET_TOKENS_PER_PAPER` | 3072 | per-paper excerpt budget |
-| `LITERATURE_EVIDENCE_SNIPPET_MAX_WORDS` | 250 | evidence words per paper |
+| `LITERATURE_PAPERS_PER_SUBQUERY` | 50 | Europe PMC results fetched per sub-query |
+| `LITERATURE_PARAGRAPHS_PER_SUBQUERY` | 16 | top-BM25 paragraphs kept per sub-query |
+| `LITERATURE_PARAGRAPHS_PER_JUDGE_BATCH` | 128 | paragraphs per Stage-3 LLM call |
+| `LITERATURE_MAX_PARAGRAPH_WORDS` | 250 | window size before a long paragraph is split |
+| `LITERATURE_PARAGRAPH_OVERLAP_WORDS` | 50 | overlap between adjacent split windows |
+| `LITERATURE_BM25_STEMMING` | on | Snowball stemming for BM25 (`0` to disable) |
 | `LITERATURE_FILTER_TEMPERATURE` | 0.1 | relevance-judge temperature |
+
+`paragraphs_per_judge_batch` should be `>= paragraphs_per_subquery * max_query_count`
+so the whole pool is judged in one call — the judge ranks globally, but results from
+several batches are only concatenated in batch order, so a smaller value silently
+degrades the ranking to per-batch. Raise all three knobs together.
 
 ---
 
@@ -247,6 +273,7 @@ main.py                        CLI entrypoint
 librarian/
   agent.py                     the retrieval pipeline (start here)
   config.py                    tuning knobs (env-var overridable)
+  tracing_port.py              TracingPort protocol + no-op default (optional tracer=)
   llm_client.py                minimal OpenAI-compatible client
   literature_search.py         Europe PMC search
   jats.py                      JATS full-text XML -> body paragraphs

--- a/librarian/agent.py
+++ b/librarian/agent.py
@@ -42,6 +42,7 @@ from librarian.config import load_runtime_config
 from librarian.jats import extract_body_paragraphs
 from librarian.literature_search import search_scientific_literature_structured
 from librarian.llm_client import create_llm_client, parse_json_response
+from librarian.tracing_port import NullTracer, TracingPort
 
 logging.getLogger("bm25s").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
@@ -488,11 +489,20 @@ class LibrarianAgent:
         verbose: bool = False,
         llm_base_url: Optional[str] = None,
         llm_model_name: Optional[str] = None,
+        tracer: Optional[TracingPort] = None,
     ):
+        """Build a librarian ready to retrieve evidence for a query.
+
+        :param tracer: Span-tracing adapter (see ``tracing_port.py``). Defaults
+            to ``NullTracer`` (no-op) — pass your own backend's adapter to
+            trace a real run.
+        :type tracer: TracingPort or None
+        """
         # Full text is the default retrieval path; the flag is kept for harness
         # compatibility (turning it off falls back to abstract-only paragraphs).
         self.full_text_enrichment = full_text_enrichment
         self.verbose = verbose
+        self._tracer: TracingPort = tracer if tracer is not None else NullTracer()
 
         # Progress reporting: set per-run in run(); _progress() no-ops when unset.
         self._on_progress: Optional[Callable[[str], None]] = None
@@ -529,6 +539,10 @@ class LibrarianAgent:
         if self._on_progress is not None:
             self._on_progress(message)
 
+    def _trace_json(self, payload: Any) -> str:
+        """Serialize compact trace payloads safely for span attributes."""
+        return json.dumps(payload, default=str, ensure_ascii=True)
+
     def _on_filter_batch_done(self, _future) -> None:
         """Bump the shared filter-batch counter and report N/M to the callback."""
         with self._filter_lock:
@@ -559,49 +573,66 @@ class LibrarianAgent:
             .replace("{additional_context}", additional_context)
         )
 
-        # max_tokens=8192 (NOT 1024): the claude prompt's JSON response is long;
-        # truncation → parse failure → a single raw-question search → bad retrieval.
-        response = self.llm.chat_completion(
-            [
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": prompt},
-            ],
-            temperature=0.3,
-            max_tokens=8192,
-        )
-        parsed = parse_json_response(response)
-        queries = parsed.get("queries", []) if isinstance(parsed, dict) else []
-        if not queries:
-            # Retry once, deterministically, demanding strict JSON before falling
-            # back to the raw question.
-            retry_messages = [
-                {
-                    "role": "system",
-                    "content": (
-                        "Return only valid JSON with a 'queries' array of Europe "
-                        'PMC query strings, e.g. {"queries": ["q1", "q2"]}. '
-                        "No prose, no markdown."
-                    ),
-                },
-                {"role": "user", "content": prompt},
-            ]
-            retry = self.llm.chat_completion(
-                retry_messages, temperature=0.0, max_tokens=8192
+        with self._tracer.start_span(
+            "librarian.generate_queries",
+            attributes={
+                "openinference.span.kind": "CHAIN",
+                "input.value": self._trace_json({"query": query}),
+                "input.mime_type": "application/json",
+            },
+        ) as span:
+            # max_tokens=8192 (NOT 1024): the claude prompt's JSON response is
+            # long; truncation → parse failure → a single raw-question search
+            # → bad retrieval.
+            response = self.llm.chat_completion(
+                [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=0.3,
+                max_tokens=8192,
             )
-            parsed = parse_json_response(retry)
+            parsed = parse_json_response(response)
             queries = parsed.get("queries", []) if isinstance(parsed, dict) else []
-        if not queries:
-            self._log("query-gen failed to parse; falling back to raw question")
-            queries = [query]
+            if not queries:
+                # Retry once, deterministically, demanding strict JSON before
+                # falling back to the raw question.
+                retry_messages = [
+                    {
+                        "role": "system",
+                        "content": (
+                            "Return only valid JSON with a 'queries' array of Europe "
+                            'PMC query strings, e.g. {"queries": ["q1", "q2"]}. '
+                            "No prose, no markdown."
+                        ),
+                    },
+                    {"role": "user", "content": prompt},
+                ]
+                retry = self.llm.chat_completion(
+                    retry_messages, temperature=0.0, max_tokens=8192
+                )
+                parsed = parse_json_response(retry)
+                queries = parsed.get("queries", []) if isinstance(parsed, dict) else []
+            if not queries:
+                self._log("query-gen failed to parse; falling back to raw question")
+                queries = [query]
 
-        # Dedup (preserve order) and cap.
-        seen, unique = set(), []
-        for q in queries:
-            q = str(q).strip()
-            if q and q not in seen:
-                seen.add(q)
-                unique.append(q)
-        result = unique[: self._max_queries]
+            # Dedup (preserve order) and cap.
+            seen, unique = set(), []
+            for q in queries:
+                q = str(q).strip()
+                if q and q not in seen:
+                    seen.add(q)
+                    unique.append(q)
+            result = unique[: self._max_queries]
+            self._tracer.set_span_attributes(
+                span,
+                {
+                    "search.query_count": len(result),
+                    "output.value": self._trace_json({"queries": result}),
+                    "output.mime_type": "application/json",
+                },
+            )
         self._log(f"generated {len(result)} queries")
         return result
 
@@ -614,11 +645,29 @@ class LibrarianAgent:
         """
         from librarian.query_validation.batch_validator import BatchQueryValidator
 
-        report = BatchQueryValidator().validate_queries(queries)
-        valid = [r["query"] for r in report["results"] if r["valid"]]
-        if self.verbose and len(valid) != len(queries):
-            self._log(f"query validation kept {len(valid)}/{len(queries)}")
-        return valid or queries
+        with self._tracer.start_span(
+            "librarian.validate_queries",
+            attributes={
+                "openinference.span.kind": "CHAIN",
+                "search.query_count.input": len(queries),
+                "input.value": self._trace_json({"queries": queries}),
+                "input.mime_type": "application/json",
+            },
+        ) as span:
+            report = BatchQueryValidator().validate_queries(queries)
+            valid = [r["query"] for r in report["results"] if r["valid"]]
+            if self.verbose and len(valid) != len(queries):
+                self._log(f"query validation kept {len(valid)}/{len(queries)}")
+            result = valid or queries
+            self._tracer.set_span_attributes(
+                span,
+                {
+                    "search.query_count.valid": len(result),
+                    "output.value": self._trace_json({"queries": result}),
+                    "output.mime_type": "application/json",
+                },
+            )
+        return result
 
     # ── Stage 2: per-sub-query retrieval + paragraph ranking ─────────────────
 
@@ -906,12 +955,13 @@ class LibrarianAgent:
         with self._filter_lock:
             self._filter_total += len(batches)
         ranked_ids: List[str] = []
+        bound_evaluate = self._tracer.bind_current_trace_context(self._evaluate_batch)
         # Judge batches only wait on the LLM (network I/O) — size to
         # _JUDGE_WORKERS, not the CPU count.
         with ThreadPoolExecutor(max_workers=_JUDGE_WORKERS) as pool:
             futures = []
             for batch in batches:
-                future = pool.submit(self._evaluate_batch, query, batch, template)
+                future = pool.submit(bound_evaluate, query, batch, template)
                 future.add_done_callback(self._on_filter_batch_done)
                 futures.append(future)
             for future in futures:  # submission order == batch order
@@ -991,7 +1041,41 @@ class LibrarianAgent:
                 "LibrarianAgent only supports max_loops=1 (single pass)."
             )
         self._on_progress = on_progress
-        return self._run(query)
+
+        with self._tracer.start_span(
+            "librarian.run",
+            attributes={
+                "openinference.span.kind": "CHAIN",
+                "input.value": self._trace_json({"query": query}),
+                "input.mime_type": "application/json",
+            },
+        ) as run_span:
+            try:
+                evidence_items = self._run(query)
+            except Exception as exc:
+                self._tracer.mark_span_error(run_span, exc)
+                raise
+            self._tracer.set_span_attributes(
+                run_span,
+                {
+                    "retrieval.evidence_count": len(evidence_items),
+                    "output.value": self._trace_json(
+                        {
+                            "evidence_count": len(evidence_items),
+                            "evidence": [
+                                {
+                                    "pmid": p.get("pmid"),
+                                    "title": p.get("title"),
+                                    "year": p.get("year"),
+                                }
+                                for p in evidence_items[:25]
+                            ],
+                        }
+                    ),
+                    "output.mime_type": "application/json",
+                },
+            )
+        return evidence_items
 
     def _run(self, query: str) -> List[Dict[str, Any]]:
         """Internal implementation of the single-pass retrieval pipeline."""
@@ -1008,15 +1092,37 @@ class LibrarianAgent:
         # pool, merging duplicate/overlapping selections. This flat paragraph
         # pool is what Stage 3 judges.
         self._progress(f"Searching Europe PMC · {len(queries)} sub-queries")
-        # One CPU-bound thread per sub-query, capped at the CPUs actually
-        # available so a large max_query_count can't oversubscribe a small
-        # container.
-        stage2_workers = min(max(len(queries), 1), _available_cpus())
-        with ThreadPoolExecutor(max_workers=stage2_workers) as pool:
-            per_subquery = pool.map(self._paragraphs_for_subquery, queries)
-        paragraphs = _merge_selected_paragraphs(
-            [para for subquery_paras in per_subquery for para in subquery_paras]
-        )
+        with self._tracer.start_span(
+            "librarian.stage2_paragraphs",
+            attributes={
+                "openinference.span.kind": "CHAIN",
+                "search.query_count": len(queries),
+                "input.value": self._trace_json({"queries": queries}),
+                "input.mime_type": "application/json",
+            },
+        ) as stage2_span:
+            bound_stage2 = self._tracer.bind_current_trace_context(
+                self._paragraphs_for_subquery
+            )
+            # One CPU-bound thread per sub-query, capped at the CPUs
+            # actually available so a large max_query_count can't
+            # oversubscribe a small container.
+            stage2_workers = min(max(len(queries), 1), _available_cpus())
+            with ThreadPoolExecutor(max_workers=stage2_workers) as pool:
+                per_subquery = pool.map(bound_stage2, queries)
+            paragraphs = _merge_selected_paragraphs(
+                [para for subquery_paras in per_subquery for para in subquery_paras]
+            )
+            self._tracer.set_span_attributes(
+                stage2_span,
+                {
+                    "paragraph.count": len(paragraphs),
+                    "output.value": self._trace_json(
+                        {"paragraph_count": len(paragraphs)}
+                    ),
+                    "output.mime_type": "application/json",
+                },
+            )
         self._log(f"{len(paragraphs)} paragraphs after Stage 2")
         self._progress(f"Found {len(paragraphs)} candidate paragraphs")
         if not paragraphs:
@@ -1029,7 +1135,26 @@ class LibrarianAgent:
         # relevant. Stage 3's output IS the final set — variable size, with
         # no final top_k cap applied on top of the judge's decision.
         self._progress("Judging paragraph relevance")
-        relevant_papers = self._relevance_filter(query, paragraphs)
+        with self._tracer.start_span(
+            "librarian.filter_relevance",
+            attributes={
+                "openinference.span.kind": "CHAIN",
+                "paragraph.count": len(paragraphs),
+                "input.value": self._trace_json({"paragraph_count": len(paragraphs)}),
+                "input.mime_type": "application/json",
+            },
+        ) as filter_span:
+            relevant_papers = self._relevance_filter(query, paragraphs)
+            self._tracer.set_span_attributes(
+                filter_span,
+                {
+                    "paper.count.relevant": len(relevant_papers),
+                    "output.value": self._trace_json(
+                        {"relevant_count": len(relevant_papers)}
+                    ),
+                    "output.mime_type": "application/json",
+                },
+            )
 
         self.last_run_debug = {
             "search_queries": queries,

--- a/librarian/agent.py
+++ b/librarian/agent.py
@@ -670,13 +670,13 @@ class LibrarianAgent:
         ``run`` can fan these out, one thread per sub-query, with no shared
         state.
         """
-        try:
-            papers = search_scientific_literature_structured(
-                subquery, page_size=self._papers_per_subquery
-            )
-        except Exception as exc:  # network/parse failure → skip this sub-query
-            self._log(f"search failed for {subquery!r}: {exc}")
-            return []
+        # A search failure propagates out of the thread pool and fails the
+        # run, so the caller can tell "the search broke" apart from "no
+        # literature found" — silently returning [] here would surface a
+        # Europe PMC outage as an empty result set.
+        papers = search_scientific_literature_structured(
+            subquery, page_size=self._papers_per_subquery
+        )
 
         pool: List[Dict[str, Any]] = []
         for paper in papers:

--- a/librarian/agent.py
+++ b/librarian/agent.py
@@ -133,6 +133,22 @@ def _available_cpus() -> int:
 # ── Pure helpers (no network) ────────────────────────────────────────────────
 
 
+def _first_affiliation(paper: Dict[str, Any]) -> str:
+    """The first non-empty author affiliation on a Europe PMC record, or ''.
+
+    literature_search.py carries a full per-author ``authorsWithAffiliations``
+    list, but every display consumer shows a single institution line. The
+    record keeps just this one string and drops the list.
+    """
+    for entry in paper.get("authorsWithAffiliations") or []:
+        if not isinstance(entry, dict):
+            continue
+        affiliation = str(entry.get("affiliation") or "").strip()
+        if affiliation:
+            return affiliation
+    return ""
+
+
 def _candidate_id(paper: Dict[str, Any]) -> str:
     """Stable per-paper id: PMID → EPMC id → DOI → title → object identity.
 
@@ -737,6 +753,7 @@ class LibrarianAgent:
             "epmcId": str(paper.get("epmcId") or ""),
             "epmcSource": str(paper.get("epmcSource") or paper.get("sourceCode") or ""),
             "url": str(paper.get("url") or ""),
+            "affiliation": _first_affiliation(paper),
             "has_fulltext": bool(paper.get("inEPMC") or paper.get("hasFreeFullText")),
         }
 

--- a/librarian/agent.py
+++ b/librarian/agent.py
@@ -267,13 +267,30 @@ def _bm25_rank(query: str, paragraphs: List[str]) -> List[Tuple[int, float]]:
     return [(int(idxs[0][i]), float(scores[0][i])) for i in range(len(idxs[0]))]
 
 
+# Paper metadata mixed into a paragraph's BM25 document (scoring only — never
+# the returned evidence text), so a sub-query naming it matches at retrieval
+# too. The abstract carries the whole citation (also the fields the Stage-3
+# judge sees); body chunks carry ONLY the year. Author/journal/title would
+# boost every body chunk of a paper equally, hiding which paragraph actually
+# matched — so they stay on the abstract; year is a harmless filter-like
+# token every chunk can carry.
+_ABSTRACT_BM25_FIELDS = ("title", "authors", "journal", "year")
+_BODY_BM25_FIELDS = ("year",)
+
+
+def _bm25_metadata(paper: Dict[str, Any], fields: Tuple[str, ...]) -> str:
+    """Space-joined values of ``fields`` from ``paper``, for the BM25 document."""
+    return " ".join(str(paper.get(field) or "").strip() for field in fields).strip()
+
+
 def _bm25_doc(record: Dict[str, Any]) -> str:
-    """BM25 document for a paragraph record: text + section title/type."""
+    """BM25 document for a paragraph record: text + section title/type + metadata."""
     return " ".join(
         [
             str(record.get("text", "")),
             str(record.get("section_title", "")),
             str(record.get("section_type", "")),
+            str(record.get("bm25_metadata", "")),
         ]
     )
 
@@ -629,11 +646,14 @@ class LibrarianAgent:
                     "text": abstract,
                     "section_title": "Abstract",
                     "section_type": "abstract",
+                    "bm25_metadata": _bm25_metadata(paper, _ABSTRACT_BM25_FIELDS),
                 }
             )
 
         if self.full_text_enrichment:
+            body_metadata = _bm25_metadata(paper, _BODY_BM25_FIELDS)
             for record in self._fetch_body_paragraphs(paper):
+                record["bm25_metadata"] = body_metadata
                 records.append(record)
 
         for source_index, record in enumerate(records):
@@ -861,13 +881,13 @@ class LibrarianAgent:
             paper_id = _candidate_id(paper)
             paper_by_id[paper_id] = paper
             paragraph_id = f"paragraph_{paragraph_index}"
+            # Metadata shown to the judge — the same fields folded into the
+            # abstract's BM25 doc at Stage 2 (_ABSTRACT_BM25_FIELDS).
+            item = {field: paper.get(field, "N/A") for field in _ABSTRACT_BM25_FIELDS}
             items.append(
                 {
                     "id": paragraph_id,
-                    "title": paper.get("title", "N/A"),
-                    "authors": paper.get("authors", "N/A"),
-                    "journal": paper.get("journal", "N/A"),
-                    "year": paper.get("year", "N/A"),
+                    **item,
                     "sentences": _build_sentence_items(
                         paragraph_id,
                         paper_id,

--- a/librarian/agent.py
+++ b/librarian/agent.py
@@ -476,28 +476,6 @@ def _group_contiguous_spans(sentences: List[_Sentence]) -> List[str]:
     return [" ".join(span) for span in spans]
 
 
-def _truncate_spans_to_words(spans: List[str], max_words: int) -> List[str]:
-    """Cap the total word count across spans, preserving span boundaries.
-
-    Words are kept greedily in order; the span that crosses the budget is
-    word-sliced and later spans are dropped, so ``" ".join`` of the result
-    holds the first ``max_words`` words.
-    """
-    out: List[str] = []
-    used = 0
-    for span in spans:
-        if used >= max_words:
-            break
-        words = span.split()
-        remaining = max_words - used
-        if len(words) > remaining:
-            out.append(" ".join(words[:remaining]))
-            break
-        out.append(span)
-        used += len(words)
-    return out
-
-
 # ── Agent ────────────────────────────────────────────────────────────────────
 
 
@@ -533,7 +511,6 @@ class LibrarianAgent:
         self._paragraphs_per_judge_batch = runtime.paragraphs_per_judge_batch
         self._max_paragraph_words = runtime.max_paragraph_words
         self._paragraph_overlap_words = runtime.paragraph_overlap_words
-        self._evidence_snippet_max_words = runtime.evidence_snippet_max_words
         self._filter_temperature = runtime.filter_temperature
 
         self.llm = create_llm_client(
@@ -728,14 +705,9 @@ class LibrarianAgent:
             if span and span.strip()
         ]
         abstract = str(paper.get("abstract") or "").strip()
-        spans = judge_spans or ([abstract] if abstract else [])
-        # Hard cap the TOTAL evidence at the word budget (~250, OpenScholar
-        # passage size). Sentence accumulation in the filter stops once the
-        # budget is reached, but the last sentence can overshoot, so bound it
-        # here too.
-        evidence_snippets = _truncate_spans_to_words(
-            spans, self._evidence_snippet_max_words
-        )
+        # Every span the judge cited for this paper — no word cap. Falls back
+        # to the abstract as a single span when the judge cited nothing.
+        evidence_snippets = judge_spans or ([abstract] if abstract else [])
         paper_id = _candidate_id(paper)
         return {
             "evidence_snippets": evidence_snippets,

--- a/librarian/config.py
+++ b/librarian/config.py
@@ -30,9 +30,6 @@ _DEFAULT_PARAGRAPHS_PER_JUDGE_BATCH = 128
 # match that straddles a cut intact.
 _DEFAULT_MAX_PARAGRAPH_WORDS = 250
 _DEFAULT_PARAGRAPH_OVERLAP_WORDS = 50
-# Words of evidence per paper handed to the summarizer: a contiguous slice of
-# the paper's cited sentences. 250 matches OpenScholar's passage size.
-_DEFAULT_EVIDENCE_SNIPPET_MAX_WORDS = 250
 # Relevance-filter LLM temperature. 0.1 is the winning config; set to 0 for
 # deterministic, reproducible filtering.
 _DEFAULT_FILTER_TEMPERATURE = 0.1
@@ -59,7 +56,6 @@ class LibrarianRuntimeConfig:
     paragraphs_per_judge_batch: int
     max_paragraph_words: int
     paragraph_overlap_words: int
-    evidence_snippet_max_words: int
     filter_temperature: float
 
 
@@ -99,11 +95,6 @@ def load_runtime_config() -> LibrarianRuntimeConfig:
         paragraph_overlap_words=_env_override(
             "LITERATURE_PARAGRAPH_OVERLAP_WORDS",
             _DEFAULT_PARAGRAPH_OVERLAP_WORDS,
-            int,
-        ),
-        evidence_snippet_max_words=_env_override(
-            "LITERATURE_EVIDENCE_SNIPPET_MAX_WORDS",
-            _DEFAULT_EVIDENCE_SNIPPET_MAX_WORDS,
             int,
         ),
         filter_temperature=_env_override(

--- a/librarian/prompts/europepmc_claude_librarian.md
+++ b/librarian/prompts/europepmc_claude_librarian.md
@@ -1,6 +1,12 @@
 You are a biology research librarian expert in Europe PMC search syntax, tasked with
 formulating MULTIPLE diverse search queries to achieve MAXIMUM RECALL.
 
+LANGUAGE: the user's question may be in any language, but Europe PMC indexes titles and
+abstracts in English. ALWAYS write your search terms in English — translate the question's
+concepts (genes, diseases, methods) into their standard English biomedical terminology.
+Never emit a LANG: filter unless the user explicitly asks for papers in a specific language;
+constraining language discards nearly the whole corpus.
+
 TEMPORAL CONTEXT:
 - Today's date is {today_date}.
 - The current year is {today_year}.
@@ -10,6 +16,9 @@ TEMPORAL CONTEXT:
 - Always include the current partial unit: "last two years" includes this year,
   "last two months" includes this month.
 - Example: if today is 2026-03-18, "last two years" → PUB_YEAR:[2024 TO 2026].
+- If the user asks for an open-ended window such as "since YYYY", "YYYY onwards", or
+  "from YYYY", use {today_year} as the upper bound — never your own training cutoff.
+  Example: if today is 2026-03-18, "2021 onwards" → PUB_YEAR:[2021 TO 2026].
 
 ---
 
@@ -18,6 +27,11 @@ TEMPORAL CONTEXT:
 Your job is to find EVERY relevant paper. A downstream relevance filter handles precision. Your job handles recall. The single biggest recall failure in boolean search is over-constraining queries with too many AND operators.
 
 **Default mindset: broad and diverse. Structured syntax is a precision tool — use it sparingly and only where it genuinely helps.**
+
+Each query does double duty: besides retrieving papers, its keywords — field tags, quotes and AND/OR stripped away — are what ranks the retrieved passages. So every query must read as a meaningful bag of scientific content words on its own. Two consequences:
+
+- Keep synonym chains purposeful. Every extra OR'd synonym dilutes the ranking signal, so expand where a term genuinely varies in the literature, not to pad the list.
+- Never emit a query whose only content is filters (`PUB_YEAR:`, `SRC:`, `OPEN_ACCESS:`, `HAS_*:`). They contribute nothing to ranking. Attach filters to a query that carries real content words.
 
 ---
 
@@ -32,7 +46,16 @@ For budgets of 1-3 queries, put the strongest fielded/boolean Europe PMC queries
 
 ## MANDATORY QUERY STRUCTURE RULES
 
-### RULE 1 — Baseline plain-text queries are REQUIRED
+### RULE 1 — Always quote multi-word field values
+
+A field value of two or more words MUST be quoted. An unquoted one is a syntax error and the query is discarded before it ever runs.
+
+- ✅ `TITLE:"lung cancer"` — quoted
+- ❌ `TITLE:lung cancer` — discarded
+
+Single words need no quotes (`GENE_PROTEIN:Cas9` is fine), but quoting them anyway is always safe.
+
+### RULE 2 — Baseline plain-text queries are REQUIRED
 
 At least 30–40% of your queries MUST be plain-text queries with NO field specifiers whatsoever — just keyword phrases, possibly joined with OR or AND for core concepts.
 These are your most important queries for recall.
@@ -49,26 +72,28 @@ Good plain-text baseline examples:
 Bad (over-specified, loses recall):
 - `TITLE:"CRISPR" AND ABSTRACT:"cancer" AND MESH:"Neoplasms"`
 
-### RULE 2 — Hard AND limit: maximum 2 AND operators per query
+### RULE 3 — Hard AND limit: maximum 2 AND operators per query
 
 Every AND is a mandatory filter that multiplies the chance of zero results.
 **No query may contain more than 2 AND operators.**
 
 If you feel the need for 3+ AND operators, you are writing one query that should be 3 separate queries. Split them.
 
-### RULE 3 — Prefer OR inside queries, AND between truly co-required concepts
+### RULE 4 — Prefer OR inside queries, AND between truly co-required concepts
 
 - Use OR to expand synonyms within a concept: `(TITLE:"cancer" OR TITLE:"tumor" OR TITLE:"carcinoma")`
 - Use AND only when BOTH concepts MUST appear in the same paper to be relevant
 - When uncertain, split into two queries rather than using AND
 
-### RULE 4 — Self-check before emitting each query
+### RULE 5 — Self-check before emitting each query
 
 Before including a query in your output, ask:
 > "If I ran this on a boolean engine right now, would it return at least 50 papers
 > on this topic?"
 
 If the answer is no: remove a field specifier, replace an AND with OR, or split.
+
+This bar does not apply to Tier 3 (precision) queries — those are meant to be narrow, and a handful of results is a success.
 
 ---
 
@@ -239,6 +264,7 @@ Use these strategies to ensure complementary coverage:
 
 ## WHAT NOT TO DO
 
+- ❌ Do not leave a multi-word field value unquoted — `TITLE:lung cancer` is discarded; write `TITLE:"lung cancer"`
 - ❌ Do not chain 3+ AND operators in one query
 - ❌ Do not use `AUTH_FIRST:` or `AUTH_LAST:` — they are not valid search fields
 - ❌ Do not use `DATA_AVAILABILITY:` — not a valid section field; use `BODY:"data availability"` or `HAS_DATA:y`

--- a/librarian/tracing_port.py
+++ b/librarian/tracing_port.py
@@ -1,0 +1,69 @@
+"""Tracing port the librarian depends on — no tracing-backend imports.
+
+Defines the tracing contract :class:`~librarian.agent.LibrarianAgent` calls
+into, plus :class:`NullTracer`, the default adapter used when no tracer is
+injected. To trace real runs, implement ``TracingPort`` against your own
+backend (Phoenix, OpenTelemetry, ...) and pass it as ``LibrarianAgent(tracer=...)``
+— nothing in this module knows that backend exists.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import (
+    Any,
+    Callable,
+    ContextManager,
+    Iterator,
+    Mapping,
+    Optional,
+    Protocol,
+    TypeVar,
+)
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class TracingPort(Protocol):
+    """Contract the librarian depends on for span tracing. No tracing backend implied."""
+
+    def start_span(
+        self, name: str, *, attributes: Optional[Mapping[str, Any]] = None
+    ) -> ContextManager[Any]:
+        """Start a span named ``name``, yielding it (or ``None``) as a context manager."""
+        ...
+
+    def set_span_attributes(
+        self, span: Any, attributes: Optional[Mapping[str, Any]]
+    ) -> None:
+        """Attach ``attributes`` to ``span``."""
+        ...
+
+    def mark_span_error(self, span: Any, exc: Exception) -> None:
+        """Record ``exc`` on ``span`` and mark it as failed."""
+        ...
+
+    def bind_current_trace_context(self, fn: F) -> F:
+        """Wrap ``fn`` so it keeps the calling span when run on another thread."""
+        ...
+
+
+class NullTracer:
+    """Default adapter: every operation is a no-op. Ships with the librarian."""
+
+    @contextmanager
+    def start_span(
+        self, name: str, *, attributes: Optional[Mapping[str, Any]] = None
+    ) -> Iterator[None]:
+        yield None
+
+    def set_span_attributes(
+        self, span: Any, attributes: Optional[Mapping[str, Any]]
+    ) -> None:
+        pass
+
+    def mark_span_error(self, span: Any, exc: Exception) -> None:
+        pass
+
+    def bind_current_trace_context(self, fn: F) -> F:
+        return fn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "librarian"
-version = "0.1.0"
+version = "0.2.0"
 description = "A life-sciences knowledge layer for AI agents: natural-language questions to ranked Europe PMC evidence passages."
 readme = "README.MD"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -128,7 +128,7 @@ wheels = [
 
 [[package]]
 name = "librarian"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "bm25s" },


### PR DESCRIPTION
## Summary
- A paragraph's BM25 document previously carried only its own text and section title/type, so a sub-query naming an author, journal, or year couldn't match on that alone.
- Mix the paper's title/authors/journal/year into the abstract record's BM25 document, and just the year into body-chunk records — author/journal/title would boost every body chunk of a paper equally, hiding which paragraph actually matched, so those stay on the abstract only.
- Never affects the returned evidence text, scoring only.
- The Stage-3 judge item builder now reuses the same field list instead of hardcoding it twice.

Stacked on `feat/snowball-stemming`.

## Test plan
- [x] Verified metadata folding produces the expected BM25 document string
- [x] `ruff check` / `ruff format --check`