### PR TITLE
Add LLM_REASONING_EFFORT to let reasoning models run at low effort

### DIFF
--- a/librarian/llm_client.py
+++ b/librarian/llm_client.py
@@ -1,12 +1,16 @@
 """Minimal LLM client for a single OpenAI-compatible endpoint.
 
 Point it at any OpenAI-compatible ``/chat/completions`` server (a self-hosted
-vLLM instance, an OpenAI-compatible gateway, OpenAI itself, ...) with three env
-vars — nothing else to configure:
+vLLM instance, an OpenAI-compatible gateway, OpenAI itself, ...) with these
+env vars — nothing else to configure:
 
-    LLM_BASE_URL   endpoint, e.g. http://localhost:8000/v1   (the default)
-    LLM_MODEL      model name to request
-    LLM_API_KEY    bearer token (defaults to "EMPTY" for keyless servers)
+    LLM_BASE_URL         endpoint, e.g. http://localhost:8000/v1   (the default)
+    LLM_MODEL            model name to request
+    LLM_API_KEY          bearer token (defaults to "EMPTY" for keyless servers)
+    LLM_REASONING_EFFORT optional ``reasoning_effort`` value (e.g. "low") for
+                         reasoning models (GLM-5.3+, etc). Servers that don't
+                         recognize the field reject it once with a 400; the
+                         client drops it and retries automatically.
 """
 
 import json
@@ -64,11 +68,18 @@ class LLMClient:
         ).rstrip("/")
         self.api_key = api_key or os.getenv("LLM_API_KEY", "EMPTY")
         self.model_name = model_name or os.getenv("LLM_MODEL")
+        # Reasoning-model effort level (e.g. "low"); unset means don't send it.
+        self.reasoning_effort = os.getenv("LLM_REASONING_EFFORT")
 
         # Optional sampling parameters this endpoint has rejected with a 400.
         self._unsupported: set = set()
 
-        print(f"LLMClient -> url={self.base_url} model={self.model_name}")
+        effort_note = (
+            f" reasoning_effort={self.reasoning_effort}"
+            if self.reasoning_effort
+            else ""
+        )
+        print(f"LLMClient -> url={self.base_url} model={self.model_name}{effort_note}")
 
     def _url(self) -> str:
         if self.base_url.endswith("/chat/completions"):
@@ -124,6 +135,8 @@ class LLMClient:
         optional = {"temperature": temperature}
         if max_tokens is not None:
             optional["max_tokens"] = int(max_tokens)
+        if self.reasoning_effort:
+            optional["reasoning_effort"] = self.reasoning_effort
 
         last_exception = None
         for attempt in range(self.MAX_RETRIES):


### PR DESCRIPTION
## Why

`LLMClient.chat_completion` never sends `reasoning_effort`/`enable_thinking`, so
pointing it at a reasoning-controlled model (GLM-5.3+, etc.) leaves the backend
on whatever its own default reasoning depth is, for every call — including the
single large Stage-3 judge call over the whole paragraph pool.


## What

- New optional `LLM_REASONING_EFFORT` env var (e.g. `low`). When set, it's
  included as `reasoning_effort` in the chat-completion payload.
- Left unset by default — zero behavior change for anyone not setting it.
- Backends that reject the field get it dropped and the request retried
  automatically via the client's existing 400-param-rejection handling, so
  this is safe to set even against non-reasoning models.


## Test plan

- [ ] Set `LLM_REASONING_EFFORT=low` against a GLM-5.3+ (or similar) backend
      and compare wall-clock time per run against current OSS behavior.