### PR TITLE
fix: default LLM_REASONING_EFFORT to "low" so the relevance judge is not starved of output budget

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,9 +7,12 @@ Configure the LLM backend in a `.env` file (copy `.env.example`) or via env vars
     LLM_BASE_URL   e.g. http://localhost:8000/v1   (default)
     LLM_MODEL      the model name to request
     LLM_API_KEY    bearer token (defaults to "EMPTY" for keyless vLLM)
+
+    LLM_REASONING_EFFORT  "low" (default here) / "high" / "max"
 """
 
 import json
+import os
 import sys
 
 from dotenv import load_dotenv
@@ -19,6 +22,18 @@ from librarian.progress import Spinner
 
 # Load LLM_BASE_URL / LLM_MODEL / LLM_API_KEY from a .env file if present.
 load_dotenv()
+
+# Default the reasoning effort to "low" unless the environment already picked one.
+#
+# Reasoning models charge their hidden trace against the same max_tokens budget as
+# the answer. With no effort set, GLM-5.3-class models reason without a ceiling and
+# can consume the whole of _FILTER_MAX_TOKENS before emitting any JSON, so the
+# relevance judge sees an empty or truncated reply and drops the batch. Measured on
+# a vLLM-served glm-5.3-flash, same query repeated: 413s returning 0-3 passages with
+# it unset, 60-82s returning 54-58 passages at "low". Retrieval is a judging task,
+# not a writing one, so "low" is the right default; set LLM_REASONING_EFFORT to
+# override.
+os.environ.setdefault("LLM_REASONING_EFFORT", "low")
 
 DEFAULT_QUERY = "What is the role of telomere shortening in cellular senescence?"
 


### PR DESCRIPTION
## Problem

Running the repo exactly as the README documents, against a vLLM-served `glm-5.3-flash`, the Stage 3 relevance judge silently returns almost nothing and the run takes ~7 minutes. No exception is raised at any point — the run just returns few or no passages after several minutes.

The failure is variable rather than deterministic: repeats of the same query returned 0 passages once and 3 another time. It is severe degradation that can reach zero, not a guaranteed empty result.

## Mechanism

Verified in the code and against a live server:

1. `LLM_REASONING_EFFORT` is unset, so `llm_client.py:72` leaves `self.reasoning_effort = None` and line 138 never adds the key to the payload.
2. GLM-5.3 then reasons with no ceiling — nothing in the request or the server's launch args supplies a default.
3. The hidden reasoning trace is charged against the same `max_tokens` budget as the answer.
4. `_FILTER_MAX_TOKENS = 8192` (`agent.py:69`) is fixed and never scales with effort.
5. The budget is exhausted before any JSON is emitted; vLLM's reasoning parser strips the trace, leaving content `''`.
6. Recovery fails: `''` is not valid JSON, `_salvage_relevant_ids` is gated on the literal string `relevant_ids` which `''` does not contain, and the batch-halving retry hits the same wall at every depth before returning `[]`.

A representative failing log:

```
[Librarian] 100 paragraphs after Stage 2
[Librarian] filter raw response (batch=100): ''
[Librarian] filter raw response (batch=50):  ''
[Librarian] filter raw response (batch=25):  ''
[Librarian] Stage 3: 0 relevant papers
```

## Measurements

Same query (`how to remove cholesterol from mice`), same endpoint:

| `LLM_REASONING_EFFORT` | wall time | passages returned |
|---|---|---|
| unset | 413s / 414s | 0 and 3 |
| `"low"` | 60s / 82s | 54 and 58 |

An isolated probe against the same server shows both wire formats for the field are honoured identically (`chat_template_kwargs.reasoning_effort` and the top-level `reasoning_effort`), and that omitting it costs ~4x even on a trivial prompt (311 tokens / 2.0s at `"low"` vs 1389 tokens / 8.4s unset). On the real 100-paragraph judge prompt it overruns the budget entirely.

## Changes

`main.py` calls `os.environ.setdefault("LLM_REASONING_EFFORT", "low")` right after `load_dotenv()`, with an explanatory comment and a docstring line documenting the variable.

`setdefault` is used deliberately: an explicit value in the shell or in `.env` still wins. Verified both directions — with `LLM_REASONING_EFFORT=max` in the environment the value stays `max`; unset, it resolves to `low`.

Retrieval is a judging task rather than a writing one, so `"low"` is the appropriate default.

## Scope and follow-ups

This fixes the `main.py` entry point only. Two things are deliberately left out of this PR:

- `orchestrator.py:59` constructs `LibrarianAgent` the same way and is still affected.
- The deeper fix is scaling `_FILTER_MAX_TOKENS` with the effort level so the judge cannot be starved regardless of the setting — the sibling implementation this was compared against applies `{"low": 1.0, "high": 1.5, "max": 2.0}` multipliers to the output budget.

## Testing

`ruff format --check main.py` and `ruff check main.py` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
