### PR TITLE
docs: document LLM_REASONING_EFFORT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@
 LLM_BASE_URL=http://localhost:8000/v1
 LLM_MODEL=your-model-name
 LLM_API_KEY=EMPTY
+LLM_REASONING_EFFORT=low

--- a/README.MD
+++ b/README.MD
@@ -61,11 +61,12 @@ cp .env.example .env
 #   LLM_BASE_URL=http://localhost:8000/v1
 #   LLM_MODEL=your-model-name
 #   LLM_API_KEY=EMPTY   # or your provider key
+#   LLM_REASONING_EFFORT=low   # optional, reasoning models only
 
 uv run main.py "does metformin extend lifespan in mammals?"
 ```
 
-`main.py` loads `.env` automatically. You can also just export the same three variables
+`main.py` loads `.env` automatically. You can also just export the same variables
 in your shell.
 
 > **Reproducing the paper's numbers.** All reported results use **GLM-5**
@@ -277,6 +278,7 @@ editing code:
 | `LITERATURE_PARAGRAPH_OVERLAP_WORDS` | 50 | overlap between adjacent split windows |
 | `LITERATURE_BM25_STEMMING` | on | Snowball stemming for BM25 (`0` to disable) |
 | `LITERATURE_FILTER_TEMPERATURE` | 0.1 | relevance-judge temperature |
+| `LLM_REASONING_EFFORT` | unset | `reasoning_effort` sent on every chat completion (e.g. `low`, `medium`, `high`); omit for models that don't support it |
 
 `paragraphs_per_judge_batch` should be `>= paragraphs_per_subquery * max_query_count`
 so the whole pool is judged in one call — the judge ranks globally, but results from


### PR DESCRIPTION
Follow-up to #15 — the fix added `reasoning_effort` support but left it undocumented.

- `.env.example`: `LLM_REASONING_EFFORT=low` (plus the missing trailing newline)
- README quickstart: mention it as an optional var
- README config table: row describing what it does and when to omit it

🤖 Generated with [Claude Code](https://claude.com/claude-code)