### PR TITLE
feat: reuse bio-agents' literature_search instead of a local reimplementation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,11 @@ LLM_BASE_URL=http://localhost:8000/v1
 LLM_MODEL=your-model-name
 LLM_API_KEY=EMPTY
 LLM_REASONING_EFFORT=low
+
+# Optional persistent cache (search results + full text). Unset = disabled, and
+# everything is re-fetched every run. Needs the extra: `uv sync --extra cache`.
+# EPMC_CACHE_DIR=.epmc_cache
+# EPMC_CACHE_TTL_DAYS=60            # successful entries
+# EPMC_CACHE_NEGATIVE_TTL_DAYS=7    # failures, so an embargoed paper reappears
+# EPMC_CACHE_DEBUG=1                # log cache hits/misses to stderr
+# LITERATURE_EPMC_SYNONYM=true      # expand MeSH/UniProt synonyms

--- a/README.MD
+++ b/README.MD
@@ -285,6 +285,29 @@ so the whole pool is judged in one call — the judge ranks globally, but result
 several batches are only concatenated in batch order, so a smaller value silently
 degrades the ranking to per-batch. Raise all three knobs together.
 
+### Full-text cache (optional)
+
+`librarian/literature_search.py` is bio-agents' `libs/literature_search.py`, kept
+identical apart from the Redis backend, which is dropped here. Both search results
+and open-access full text are cached across runs. The cache is off unless
+`EPMC_CACHE_DIR` is set, and needs its extra installed — `uv sync --extra cache`,
+or `pip install 'librarian[cache]'`.
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `EPMC_CACHE_DIR` | unset | directory for a diskcache (SQLite) cache; unset disables caching entirely |
+| `EPMC_CACHE_TTL_DAYS` | 60 | lifetime of a cached search result or full text |
+| `EPMC_CACHE_NEGATIVE_TTL_DAYS` | 7 | lifetime of a cached *failure* — shorter so a paper that leaves embargo is not skipped for two months |
+| `EPMC_CACHE_DEBUG` | unset | `1` logs cache hits/misses to stderr |
+| `LITERATURE_EPMC_SYNONYM` | unset | `true` asks Europe PMC to expand MeSH/UniProt synonyms (broader recall) |
+
+Failures are cached because ~15% of the papers Europe PMC flags as open access have no
+fetchable `fullTextXML`. Only *permanent* statuses (400/403/404/410) are treated as
+final, and only after a confirming second request — Europe PMC intermittently 404s
+documents that do exist, and an unconfirmed negative would degrade those papers to
+abstract-only for days. Transient failures (429/5xx, timeouts) are retried on the next
+read instead.
+
 ---
 
 ## 📁 Layout

--- a/librarian/agent.py
+++ b/librarian/agent.py
@@ -8,6 +8,8 @@ Single-pass pipeline (max_loops=1, the only supported mode):
   Stage 2 — Paper-level retrieval + paragraph BM25 ranking (_paragraphs_for_subquery,
       one thread per sub-query):
         - search the sub-query against Europe PMC (papers_per_subquery papers),
+        - prefetch every open-access full text the sub-query needs as one
+          concurrent batch (literature_search.fetch_fulltext_many),
         - decompose every paper into paragraphs (abstract + full-text body chunks,
           no distinction), BM25-rank the pool against the sub-query, keep the top k
           (paragraphs_per_subquery).
@@ -36,11 +38,15 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 import bm25s
 import pysbd
-import requests
 
 from librarian.config import load_runtime_config
 from librarian.jats import extract_body_paragraphs
-from librarian.literature_search import search_scientific_literature_structured
+from librarian.literature_search import (
+    Fulltext,
+    fetch_fulltext_many,
+    normalize_pmcid,
+    search_scientific_literature_structured,
+)
 from librarian.llm_client import create_llm_client, parse_json_response
 from librarian.tracing_port import NullTracer, TracingPort
 
@@ -51,9 +57,6 @@ logger = logging.getLogger(__name__)
 _PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
 _QUERY_PROMPT_PATH = _PROMPTS_DIR / "europepmc_claude_librarian.md"
 _FILTER_PROMPT_PATH = _PROMPTS_DIR / "relevance_filter.md"
-
-# Europe PMC full-text fetch endpoint (PMC id -> JATS XML).
-_FULLTEXT_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/{pmcid}/fullTextXML"
 
 # Implementation constants — env-independent and never tuned. Every tunable knob
 # (query count, page size, evidence words, pool caps, filter batches, ...) lives
@@ -165,6 +168,20 @@ def _candidate_id(paper: Dict[str, Any]) -> str:
         source = str(paper.get("epmcSource") or paper.get("sourceCode") or "").strip()
         return f"{source}:{epmc_id}" if source else epmc_id
     return str(paper.get("doi") or paper.get("title") or id(paper))
+
+
+def _fulltext_pmcid(paper: Dict[str, Any]) -> str:
+    """The PMC id whose full text this paper is worth fetching, or ''.
+
+    Gated on the open-access flags Europe PMC returned with the search, then
+    ``fullTextIds[0]`` with ``pmcid`` as the fallback. Pure, so the batch prefetch
+    and the per-paper lookup derive the same key from the same record.
+    """
+    if not (paper.get("inEPMC") or paper.get("hasFreeFullText")):
+        return ""
+    full_text_ids = paper.get("fullTextIds") or []
+    raw_id = (full_text_ids[0] if full_text_ids else "") or paper.get("pmcid") or ""
+    return normalize_pmcid(raw_id) if str(raw_id).strip() else ""
 
 
 def _merge_selected_paragraphs(
@@ -672,12 +689,15 @@ class LibrarianAgent:
     # ── Stage 2: per-sub-query retrieval + paragraph ranking ─────────────────
 
     def _paragraph_records_for_paper(
-        self, paper: Dict[str, Any]
+        self, paper: Dict[str, Any], fulltexts: Dict[str, Fulltext]
     ) -> List[Dict[str, Any]]:
         """One paper → its paragraph records: abstract + full-text body chunks.
 
         Abstract and body paragraphs share one pool with no distinction. Each
         record carries a ``paper`` reference so its metadata is reachable later.
+
+        ``fulltexts`` is the batch this sub-query already fetched in parallel, keyed
+        by normalised PMC id; this method only looks its paper up, never fetches.
         """
         records: List[Dict[str, Any]] = []
 
@@ -694,7 +714,7 @@ class LibrarianAgent:
 
         if self.full_text_enrichment:
             body_metadata = _bm25_metadata(paper, _BODY_BM25_FIELDS)
-            for record in self._fetch_body_paragraphs(paper):
+            for record in self._body_paragraphs(paper, fulltexts):
                 record["bm25_metadata"] = body_metadata
                 records.append(record)
 
@@ -727,9 +747,30 @@ class LibrarianAgent:
             subquery, page_size=self._papers_per_subquery
         )
 
+        # Every open-access full text this sub-query needs, fetched concurrently
+        # before any paper is decomposed. Fetching them one paper at a time was
+        # almost all of this thread's wall clock (up to papers_per_subquery
+        # requests × ~0.6s each) for work that is pure network wait. The pool is
+        # shared across sub-queries, so the fan-out cannot multiply into a burst
+        # against Europe PMC.
+        fulltexts: Dict[str, Fulltext] = {}
+        if self.full_text_enrichment:
+            with self._tracer.start_span(
+                "librarian.epmc_fulltext",
+                attributes={
+                    "openinference.span.kind": "RETRIEVER",
+                    "paper.count": len(papers),
+                },
+            ) as fulltext_span:
+                fulltexts = fetch_fulltext_many(_fulltext_pmcid(p) for p in papers)
+                self._tracer.set_span_attributes(
+                    fulltext_span,
+                    {"fulltext.count": sum(1 for f in fulltexts.values() if f.ok)},
+                )
+
         pool: List[Dict[str, Any]] = []
         for paper in papers:
-            pool.extend(self._paragraph_records_for_paper(paper))
+            pool.extend(self._paragraph_records_for_paper(paper, fulltexts))
 
         top = _rank_paragraphs_for_subquery(
             subquery, pool, self._paragraphs_per_subquery
@@ -778,31 +819,28 @@ class LibrarianAgent:
             "has_fulltext": bool(paper.get("inEPMC") or paper.get("hasFreeFullText")),
         }
 
-    # ── Full-text fetch + body extraction ────────────────────────────────────
+    # ── Body extraction from the prefetched full text ────────────────────────
 
-    def _fetch_body_paragraphs(self, paper: Dict[str, Any]) -> List[Dict[str, str]]:
-        """Fetch full text and return body paragraph records (or [])."""
-        if not (paper.get("inEPMC") or paper.get("hasFreeFullText")):
-            return []
-        full_text_ids = paper.get("fullTextIds") or []
-        pmcid = (full_text_ids[0] if full_text_ids else "") or paper.get("pmcid") or ""
-        pmcid = str(pmcid).strip()
+    def _body_paragraphs(
+        self, paper: Dict[str, Any], fulltexts: Dict[str, Fulltext]
+    ) -> List[Dict[str, str]]:
+        """Body paragraph records for one paper from the prefetched batch (or []).
+
+        Three ways to legitimately get nothing back, all of which leave the paper
+        abstract-only: it is not open access, its full text could not be fetched,
+        or the JATS had no usable body. Only the fetch failure is worth logging —
+        the other two are ordinary.
+        """
+        pmcid = _fulltext_pmcid(paper)
         if not pmcid:
             return []
-        return extract_body_paragraphs(self._fetch_fulltext_xml(pmcid))
-
-    def _fetch_fulltext_xml(self, pmcid: str) -> str:
-        """Fetch JATS full-text XML for a PMC id (returns '' on failure)."""
-        pmcid = pmcid.upper()
-        if pmcid.isdigit():
-            pmcid = f"PMC{pmcid}"
-        try:
-            response = requests.get(_FULLTEXT_URL.format(pmcid=pmcid), timeout=30)
-            response.raise_for_status()
-        except requests.exceptions.RequestException as exc:
-            self._log(f"full-text fetch failed for {pmcid}: {exc}")
-            return ""
-        return response.text
+        fulltext = fulltexts.get(pmcid)
+        if fulltext is None:
+            return []
+        if not fulltext.ok:
+            self._log(f"full-text fetch failed for {pmcid}: {fulltext.error}")
+            return []
+        return extract_body_paragraphs(fulltext.xml)
 
     # ── Step 5: single-pass LLM relevance filter ─────────────────────────────
 

--- a/librarian/literature_search.py
+++ b/librarian/literature_search.py
@@ -1,137 +1,700 @@
-"""Europe PMC literature search.
+"""
+Europe PMC literature search library for scientific papers.
+Provides both a LangChain-compatible retriever and a standalone structured search function.
 
-``search_scientific_literature_structured`` runs one Europe PMC REST query and
-returns a list of paper dicts (title, abstract, authors, ids, full-text
-availability, ...). The full agent wrapped this in a LangChain retriever and a
-Redis/diskcache look-aside cache; neither is needed to run the librarian, so
-this version is a single plain ``requests`` call with a small retry loop.
+Optional look-aside cache
+-------------------------
+One backend, selected by environment variable:
+
+  EPMC_CACHE_DIR       — Directory path for a diskcache (SQLite) cache.
+
+If it is unset the cache is disabled — no crash, no warning after the first.
+Entry lifetime is EPMC_CACHE_TTL_DAYS (default 60 days).
+
+NB: this is bio-agents' ``libs/literature_search`` with the Redis backend
+removed; it is otherwise kept identical, so fixes flow between the two without
+translation. bio-agents additionally supports EPMC_CACHE_REDIS_URL for
+deployments where several replicas share one cache.
+
+Two cache layers are maintained:
+  * Search-result cache  — keyed by SHA-256(query + page_size), stores Document lists.
+  * Full-text cache      — keyed by normalised PMCID, stores the XML *or* the
+                           failure that fetching it produced (see below).
+
+Full-text failures are cached too, because ~15% of the papers Europe PMC flags as
+open access have no fetchable ``fullTextXML``. A permanent failure (404/410/…) is
+remembered so later runs skip the request entirely; a transient one (429/5xx,
+timeout, connection error) is remembered only as a breadcrumb and retried on the
+next read. Negative entries expire on their own, shorter clock
+(EPMC_CACHE_NEGATIVE_TTL_DAYS, default 7) so a paper that becomes open access
+later is not skipped for the full 60 days.
+
+Set EPMC_CACHE_DEBUG=1 to log cache hits and misses to stderr.
 """
 
+import hashlib
+import json
+import os
+import sys
+import threading
 import time
-from typing import Any, Dict, List
-from urllib.parse import quote
-
 import requests
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import List, Dict, Any, Iterable
+from urllib.parse import quote
+from langchain_core.retrievers import BaseRetriever
+from langchain_core.documents import Document
+from langchain_core.callbacks import CallbackManagerForRetrieverRun
 
-_SEARCH_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/search"
-_RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+try:
+    import diskcache as _dc
+
+    _DISKCACHE_AVAILABLE = True
+except ImportError:
+    _DISKCACHE_AVAILABLE = False
+
+# diskcache uses SQLite under the hood; concurrent cache.set() calls from
+# multiple threads can race and cause "database is locked" errors.
+# This lock serializes only the write operations — HTTP requests remain parallel.
+_cache_write_lock = threading.Lock()
+
+# Module-level cache backend singleton — created once on first use.
+_cache_backend: "object | None" = None
+_cache_warned: bool = False
+# Warn once (not per-request) when the cache backend is unreachable.
+_cache_error_warned: bool = False
 
 
-def _parse_result(result: Dict[str, Any]) -> Dict[str, Any]:
-    """Convert one Europe PMC ``result`` record into the agent's paper dict."""
-    epmc_id = result.get("id", "")
-    epmc_source = result.get("source", "")
+def _warn_cache_unavailable(exc: Exception) -> None:
+    """Log a single warning when the cache backend errors (e.g. a locked db).
 
-    # Full author names and per-author affiliations from the core authorList.
-    author_full_names: List[str] = []
-    authors_with_affiliations: List[Dict[str, str]] = []
-    for author in result.get("authorList", {}).get("author", []):
-        first = author.get("firstName", "").strip()
-        last = author.get("lastName", "").strip()
-        if first and last:
-            full_name = f"{first} {last}"
-        elif last:
-            full_name = last
+    The EPMC cache is a look-aside optimization, never a hard dependency: if the
+    backend is unreachable we fall back to the live Europe PMC API. We warn only
+    once so a sustained outage doesn't spam the logs.
+    """
+    global _cache_error_warned
+    if not _cache_error_warned:
+        print(
+            f"EPMC cache backend unavailable ({exc}); serving from the live API "
+            "until it recovers.",
+            file=sys.stderr,
+        )
+        _cache_error_warned = True
+
+
+def _documents_to_jsonable(docs: List[Document]) -> List[dict]:
+    return [{"page_content": d.page_content, "metadata": d.metadata} for d in docs]
+
+
+def _documents_from_jsonable(items) -> List[Document]:
+    """Convert a list of dicts (or raw Document objects) back to Document instances.
+
+    Tolerates legacy diskcache entries that stored raw Document objects directly.
+    """
+    out = []
+    for it in items:
+        if isinstance(it, Document):
+            out.append(it)
         else:
-            full_name = author.get("fullName", "").strip()
-        author_full_names.append(full_name)
+            out.append(
+                Document(page_content=it["page_content"], metadata=it["metadata"])
+            )
+    return out
 
-        affil_list = author.get("authorAffiliationDetailsList", {}).get(
-            "authorAffiliation", []
+
+class _DiskCacheBackend:
+    """Thin wrapper around diskcache.Cache that matches the backend interface."""
+
+    def __init__(self, cache: "_dc.Cache") -> None:
+        self._cache = cache
+
+    def get(self, key: str):
+        try:
+            return self._cache.get(key)
+        except Exception as exc:  # corrupt/locked db → treat as a miss
+            _warn_cache_unavailable(exc)
+            return None
+
+    def set(self, key: str, value, expire_seconds: int) -> None:
+        try:
+            with _cache_write_lock:
+                self._cache.set(key, value, expire=expire_seconds)
+        except Exception as exc:  # best-effort write, never break retrieval
+            _warn_cache_unavailable(exc)
+
+
+def _get_cache_backend() -> "_DiskCacheBackend | None":
+    """Return the active cache backend, creating it on first call.
+
+    Selection order: EPMC_CACHE_DIR → None.
+    """
+    global _cache_backend, _cache_warned
+    if _cache_backend is not None:
+        return _cache_backend
+
+    cache_dir = os.environ.get("EPMC_CACHE_DIR", "").strip()
+    if cache_dir:
+        if not _DISKCACHE_AVAILABLE:
+            print(
+                "EPMC cache: EPMC_CACHE_DIR is set but diskcache is not installed — cache disabled.",
+                file=sys.stderr,
+            )
+            return None
+        # NB: diskcache.Cache's `timeout` kwarg is the SQLite busy-timeout in
+        # seconds (how long to retry on "database is locked"), not a cache
+        # TTL — leave it at diskcache's own default (60s). Entry lifetime is
+        # controlled separately via EPMC_CACHE_TTL_DAYS below.
+        _cache_backend = _DiskCacheBackend(_dc.Cache(cache_dir))
+        return _cache_backend
+
+    if not _cache_warned:
+        print(
+            "EPMC cache: EPMC_CACHE_DIR is not set — cache disabled. "
+            "Set it to enable persistent caching.",
+            file=sys.stderr,
         )
-        affiliation = affil_list[0].get("affiliation", "") if affil_list else ""
-        authors_with_affiliations.append(
-            {"name": full_name, "affiliation": affiliation}
-        )
+        _cache_warned = True
+    return None
 
-    # Full-text availability: Europe PMC exposes it via id/url lists, not a scalar.
-    full_text_ids = result.get("fullTextIdList", {}).get("fullTextId", [])
-    if isinstance(full_text_ids, str):
-        full_text_ids = [full_text_ids]
-    if not isinstance(full_text_ids, list):
-        full_text_ids = []
 
-    full_text_urls = result.get("fullTextUrlList", {}).get("fullTextUrl", [])
-    if isinstance(full_text_urls, dict):
-        full_text_urls = [full_text_urls]
-    if not isinstance(full_text_urls, list):
-        full_text_urls = []
+def _epmc_synonym_enabled() -> bool:
+    """Whether to ask Europe PMC to expand MeSH/UniProt synonyms (default off).
 
-    has_fulltext = bool(full_text_ids) or any(
-        str(u.get("availabilityCode", "")).upper() == "OA"
-        for u in full_text_urls
-        if isinstance(u, dict)
+    Europe PMC's REST default is ``synonym=false``. Turning it on broadens
+    recall by matching gene/organism aliases (e.g. leukolysin↔MMP25,
+    mu-opioid↔OPRM1) — useful since downstream BM25 + LLM filtering re-tightens
+    precision. Toggle with ``LITERATURE_EPMC_SYNONYM=true``.
+    """
+    return os.environ.get("LITERATURE_EPMC_SYNONYM", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
     )
 
-    url = ""
-    if epmc_source and epmc_id:
-        url = (
-            "https://europepmc.org/article/"
-            f"{quote(epmc_source, safe='')}/{quote(epmc_id, safe='')}"
-        )
 
+def _cache_key(query: str, page_size: int, synonym: bool = False) -> str:
+    """Stable cache key: SHA-256 of query + page_size (+ synonym when enabled).
+
+    ``synonym=False`` reproduces the historical key exactly, so pre-existing
+    cache entries stay valid; ``synonym=True`` gets a distinct key so the two
+    settings never collide.
+    """
+    payload = {"q": query, "n": page_size}
+    if synonym:
+        payload["syn"] = True
+    raw = json.dumps(payload, sort_keys=True)
+    return "epmc:" + hashlib.sha256(raw.encode()).hexdigest()
+
+
+# ── Full text: fetch, negative caching, parallel batch ──────────────────────
+
+# Europe PMC serves open-access full text as JATS XML from a path endpoint (no
+# query parameters, unlike /search).
+_FULLTEXT_URL = "https://www.ebi.ac.uk/europepmc/webservices/rest/{pmcid}/fullTextXML"
+
+# Statuses a retry will never fix: the document is genuinely absent, or the id is
+# malformed. Cached so later runs skip the request entirely. Everything else —
+# 429, 5xx, timeouts, connection errors — is transient: the entry is written as a
+# breadcrumb but re-fetched the next time this pmcid is read.
+_PERMANENT_FULLTEXT_STATUSES = frozenset({400, 403, 404, 410})
+
+# Pause before the confirming request that turns a permanent status into a cached
+# negative (see _request_fulltext). Long enough to ride out the brief upstream
+# episodes that produce false 404s, short enough to stay invisible: it is paid at
+# most once per pmcid, and only for the ~15% that really have no full text.
+_PERMANENT_CONFIRM_DELAY_S = 0.5
+
+# Full-text fetches only WAIT on Europe PMC (network I/O, no CPU), so this pool is
+# a fixed count independent of cores — the same reasoning as the librarian's
+# _JUDGE_WORKERS. It is module-level on purpose: every sub-query thread shares it,
+# so this is the total number of concurrent full-text requests EBI ever sees, not
+# a per-caller limit that multiplies by the sub-query fan-out.
+_FULLTEXT_WORKERS = 8
+_fulltext_pool: "ThreadPoolExecutor | None" = None
+_fulltext_pool_lock = threading.Lock()
+
+
+@dataclass(frozen=True)
+class Fulltext:
+    """One full-text fetch outcome: the JATS XML, or the failure that replaced it.
+
+    A failure is a first-class result rather than an empty string, so a caller can
+    tell "this paper has no full text" from "the fetch broke" — in production the
+    two used to be indistinguishable and both silently degraded the paper to
+    abstract-only.
+    """
+
+    pmcid: str
+    xml: str = ""
+    status: "int | None" = None
+    error: str = ""
+    from_cache: bool = False
+
+    @property
+    def ok(self) -> bool:
+        """True when the XML was retrieved (it may still be empty or unparseable)."""
+        return not self.error
+
+    @property
+    def permanent(self) -> bool:
+        """True when re-requesting this pmcid cannot change the outcome."""
+        return self.status in _PERMANENT_FULLTEXT_STATUSES
+
+
+def normalize_pmcid(pmcid: str) -> str:
+    """Upper-case a PMC id and prefix bare digits, so one paper keys one way.
+
+    :param pmcid: A PMC id in any of the forms Europe PMC hands out
+        (``PMC123``, ``pmc123``, ``123``).
+    :return: The canonical ``PMC123`` form, used for both the cache key and the URL.
+    :rtype: str
+    """
+    normalized = str(pmcid).strip().upper()
+    return f"PMC{normalized}" if normalized.isdigit() else normalized
+
+
+def _fulltext_cache_key(pmcid: str) -> str:
+    """Stable cache key for a full-text entry: literal normalised PMCID."""
+    return "epmc:ft:" + normalize_pmcid(pmcid)
+
+
+def _fulltext_from_entry(pmcid: str, entry: Any) -> "Fulltext | None":
+    """Rebuild a ``Fulltext`` from a cache entry, or None if it is unusable.
+
+    Tolerates the legacy format (a bare XML string), which pre-dates negative
+    caching and is still sitting in production caches under a 60-day TTL.
+    """
+    if isinstance(entry, str):
+        return Fulltext(pmcid=pmcid, xml=entry, status=200, from_cache=True)
+    if isinstance(entry, dict):
+        return Fulltext(
+            pmcid=pmcid,
+            xml=str(entry.get("xml") or ""),
+            status=entry.get("status"),
+            error=str(entry.get("error") or ""),
+            from_cache=True,
+        )
+    return None
+
+
+def _get_cached_fulltext(pmcid: str) -> "Fulltext | None":
+    """Look up a cached full-text outcome for *pmcid* (None on miss/disabled)."""
+    backend = _get_cache_backend()
+    if backend is None:
+        return None
+    hit = backend.get(_fulltext_cache_key(pmcid))
+    cached = _fulltext_from_entry(pmcid, hit) if hit is not None else None
+    if os.environ.get("EPMC_CACHE_DEBUG") == "1":
+        state = "miss"
+        if cached is not None:
+            state = "hit " if cached.ok else f"neg({cached.status})"
+        print(f"[epmc-cache] ft {state} pmcid={pmcid}", file=sys.stderr)
+    return cached
+
+
+def _set_cached_fulltext(result: Fulltext) -> None:
+    """Persist a fetch outcome (success or failure); no-op if the cache is off.
+
+    Failures expire on their own, shorter clock: a paper under embargo becomes
+    open access later, and a 60-day negative entry would keep it invisible for
+    two months after it became fetchable.
+    """
+    backend = _get_cache_backend()
+    if backend is None:
+        return
+    ttl_env = "EPMC_CACHE_TTL_DAYS" if result.ok else "EPMC_CACHE_NEGATIVE_TTL_DAYS"
+    ttl_days = float(os.environ.get(ttl_env, "60" if result.ok else "7"))
+    entry = {"xml": result.xml, "status": result.status, "error": result.error}
+    backend.set(_fulltext_cache_key(result.pmcid), entry, int(ttl_days * 86400))
+
+
+def _attempt_fulltext(pmcid: str) -> Fulltext:
+    """One GET for *pmcid*, with no caching and no retry."""
+    try:
+        response = requests.get(_FULLTEXT_URL.format(pmcid=pmcid), timeout=30)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        return Fulltext(
+            pmcid=pmcid,
+            status=status,
+            error=f"{status or type(exc).__name__}: {exc}",
+        )
+    return Fulltext(pmcid=pmcid, xml=response.text, status=response.status_code)
+
+
+def _request_fulltext(pmcid: str) -> Fulltext:
+    """Fetch *pmcid*, confirm any permanent verdict, and cache the outcome.
+
+    Europe PMC intermittently answers 404 for documents that do exist: a whole
+    79-fetch batch was observed 404ing, with every one of those ids serving a
+    200 and full JATS again minutes later. A permanent verdict is cached for days
+    and silently degrades the paper to abstract-only for that whole window, so it
+    has to be confirmed by a second request before it is trusted. A transient
+    failure needs no confirmation — it is already retried on the next read.
+    """
+    result = _attempt_fulltext(pmcid)
+    if not result.ok and result.permanent:
+        time.sleep(_PERMANENT_CONFIRM_DELAY_S)
+        result = _attempt_fulltext(pmcid)
+    _set_cached_fulltext(result)
+    return result
+
+
+def fetch_fulltext(pmcid: str) -> Fulltext:
+    """Full-text JATS XML for a PMC id, through the negative-aware cache.
+
+    Cache decision, in order: a cached success is returned as-is; a cached
+    *permanent* failure (404/410/…) is returned without touching the network; a
+    cached *transient* failure (429/5xx, timeout, connection error) is retried
+    now, and whatever comes back replaces the entry. A miss is fetched and cached
+    either way.
+
+    There is no in-request retry loop — the transient entry IS the retry, taken
+    on the next read. Within one librarian run that read comes for free whenever a
+    paper is found by more than one sub-query (papers are deliberately not
+    deduplicated across sub-queries).
+
+    :param pmcid: A PMC id in any form; normalised internally.
+    :type pmcid: str
+    :return: The fetch outcome — never raises, failures come back as a
+        ``Fulltext`` with ``ok`` False.
+    :rtype: Fulltext
+    """
+    normalized = normalize_pmcid(pmcid)
+    cached = _get_cached_fulltext(normalized)
+    if cached is not None and (cached.ok or cached.permanent):
+        return cached
+    return _request_fulltext(normalized)
+
+
+def _get_fulltext_pool() -> ThreadPoolExecutor:
+    """The shared full-text fetch pool, created on first use."""
+    global _fulltext_pool
+    if _fulltext_pool is None:
+        with _fulltext_pool_lock:
+            if _fulltext_pool is None:
+                _fulltext_pool = ThreadPoolExecutor(
+                    max_workers=_FULLTEXT_WORKERS, thread_name_prefix="epmc-ft"
+                )
+    return _fulltext_pool
+
+
+def fetch_fulltext_many(pmcids: Iterable[str]) -> Dict[str, Fulltext]:
+    """Fetch several full texts concurrently, keyed by normalised PMC id.
+
+    Ids are deduplicated first, so a pmcid repeated inside one batch costs one
+    request. All callers share ``_FULLTEXT_WORKERS`` slots, so the sub-query
+    fan-out above cannot multiply into a burst against Europe PMC.
+
+    :param pmcids: PMC ids in any form; blanks are dropped.
+    :type pmcids: Iterable[str]
+    :return: One ``Fulltext`` per distinct id, successes and failures alike.
+    :rtype: Dict[str, Fulltext]
+    """
+    # ponytail: two sub-query threads asking for the same pmcid at the same moment
+    # both fetch it (dedup is per batch, not global). Worst case is one duplicate
+    # GET; add a per-pmcid in-flight lock only if that shows up in the numbers.
+    unique = list(
+        dict.fromkeys(normalize_pmcid(p) for p in pmcids if str(p or "").strip())
+    )
+    if not unique:
+        return {}
     return {
-        "title": result.get("title", "No title"),
-        "authors": result.get("authorString", "Unknown authors"),
-        "authorFullNames": author_full_names,
-        "authorsWithAffiliations": authors_with_affiliations,
-        "epmcId": epmc_id,
-        "epmcSource": epmc_source,
-        "sourceCode": epmc_source,
-        "pmid": result.get("pmid", ""),
-        "pmcid": result.get("pmcid", ""),
-        "doi": result.get("doi", ""),
-        "source": "Europe PMC",
-        "url": url,
-        "abstract": result.get("abstractText", ""),
-        "journal": result.get("journalInfo", {}).get("journal", {}).get("title", ""),
-        "year": result.get("pubYear", ""),
-        "isOpenAccess": result.get("isOpenAccess", "N") == "Y",
-        "hasPDF": result.get("hasPDF", "N") == "Y",
-        "inEPMC": result.get("inEPMC", "N") == "Y",
-        "hasFreeFullText": has_fulltext,
-        "fullTextIds": full_text_ids,
-        "fullTextUrls": full_text_urls,
+        result.pmcid: result
+        for result in _get_fulltext_pool().map(fetch_fulltext, unique)
     }
+
+
+def get_cached_fulltext_xml(pmcid: str) -> "str | None":
+    """Cached full-text XML for *pmcid*, or None on miss / failure / cache disabled.
+
+    Thin compatibility wrapper over ``fetch_fulltext``'s cache: it reports only
+    successes, so a cached failure reads as a miss. New code should call
+    ``fetch_fulltext`` and inspect the ``Fulltext`` instead.
+    """
+    cached = _get_cached_fulltext(normalize_pmcid(pmcid))
+    return cached.xml if cached is not None and cached.ok else None
+
+
+def set_cached_fulltext_xml(pmcid: str, xml_text: str) -> None:
+    """Persist *xml_text* for *pmcid* as a successful entry (no-op if disabled)."""
+    _set_cached_fulltext(
+        Fulltext(pmcid=normalize_pmcid(pmcid), xml=xml_text, status=200)
+    )
+
+
+class LiteratureSearchError(RuntimeError):
+    """Raised when Europe PMC could not complete a search.
+
+    Distinct from every other failure in the retrieval pipeline: callers catch it
+    to tell the user the search itself broke, instead of reporting a search
+    outage as an absence of literature.
+    """
+
+
+class EuropePMCRetriever(BaseRetriever):
+    """Retriever that searches Europe PMC database for scientific literature.
+
+    This retriever queries the Europe PMC API to find relevant scientific papers
+    and returns them as Document objects.
+    """
+
+    page_size: int = 10
+    base_url: str = "https://www.ebi.ac.uk/europepmc/webservices/rest/search"
+
+    def _get_relevant_documents(
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun = None
+    ) -> List[Document]:
+        """
+        Internal method for LangChain to retrieve documents.
+        Queries Europe PMC API and wraps results in LangChain Document objects.
+        """
+        # Search parameters for the REST API
+        synonym_on = _epmc_synonym_enabled()
+        params = {
+            "query": query,
+            "format": "json",
+            "pageSize": self.page_size,
+            "resultType": "core",
+        }
+        if synonym_on:
+            # Europe PMC expects a lowercase string literal here.
+            params["synonym"] = "true"
+
+        # Check cache before hitting the network.
+        backend = _get_cache_backend()
+        key = _cache_key(query, self.page_size, synonym=synonym_on)
+        if backend is not None:
+            hit = backend.get(key)
+            if hit is not None:
+                if os.environ.get("EPMC_CACHE_DEBUG") == "1":
+                    print(
+                        f"[epmc-cache] search hit  key={key[:16]} q_preview={query[:80]}",
+                        file=sys.stderr,
+                    )
+                return _documents_from_jsonable(hit)
+
+        if os.environ.get("EPMC_CACHE_DEBUG") == "1":
+            print(
+                f"[epmc-cache] search miss key={key[:16]} q_preview={query[:80]}",
+                file=sys.stderr,
+            )
+
+        _max_attempts = 4
+        for _attempt in range(_max_attempts):
+            try:
+                response = requests.get(self.base_url, params=params, timeout=30)
+                response.raise_for_status()
+                break
+            except requests.exceptions.RequestException as e:
+                if _attempt < _max_attempts - 1 and (
+                    getattr(getattr(e, "response", None), "status_code", None)
+                    in (429, 500, 502, 503, 504)
+                    or isinstance(e, requests.exceptions.ConnectionError)
+                ):
+                    time.sleep(2**_attempt)
+                    continue
+                # A network/HTTP failure is not "zero results": propagate it so
+                # callers can tell an unreachable Europe PMC from an empty search.
+                # Returning [] here reached users as "no literature found".
+                raise LiteratureSearchError(f"Europe PMC request failed: {e}") from e
+
+        try:
+            data = response.json()
+            result_list = data.get("resultList", {}).get("result", [])
+
+            documents = []
+            for result in result_list:
+                epmc_id = result.get("id", "")
+                epmc_source = result.get("source", "")
+                title = result.get("title", "No title")
+                abstract = result.get("abstractText", "No abstract available")
+                authors = result.get("authorString", "Unknown authors")
+                pmid = result.get("pmid", "")
+                pmcid = result.get("pmcid", "")
+                doi = result.get("doi", "")
+
+                journal_info = result.get("journalInfo", {})
+                journal = journal_info.get("journal", {}).get("title", "")
+                year = result.get("pubYear", "")
+
+                # Extract full author names and per-author affiliations from authorList (core result type)
+                author_full_names = []
+                authors_with_affiliations = []
+                author_list = result.get("authorList", {}).get("author", [])
+                for author_entry in author_list:
+                    first = author_entry.get("firstName", "").strip()
+                    last = author_entry.get("lastName", "").strip()
+                    if first and last:
+                        full_name = f"{first} {last}"
+                    elif last:
+                        full_name = last
+                    else:
+                        full_name = author_entry.get("fullName", "").strip()
+
+                    author_full_names.append(full_name)
+
+                    # Pull the first affiliation string if present
+                    affil_details = author_entry.get("authorAffiliationDetailsList", {})
+                    affil_list = affil_details.get("authorAffiliation", [])
+                    affiliation = (
+                        affil_list[0].get("affiliation", "") if affil_list else ""
+                    )
+
+                    authors_with_affiliations.append(
+                        {"name": full_name, "affiliation": affiliation}
+                    )
+
+                # Full text availability indicators
+                is_oa = result.get("isOpenAccess", "N") == "Y"
+                has_pdf = result.get("hasPDF", "N") == "Y"
+                in_epmc = result.get("inEPMC", "N") == "Y"
+                full_text_id_list = result.get("fullTextIdList", {}).get(
+                    "fullTextId", []
+                )
+                if isinstance(full_text_id_list, str):
+                    full_text_id_list = [full_text_id_list]
+                if not isinstance(full_text_id_list, list):
+                    full_text_id_list = []
+                full_text_url_list = result.get("fullTextUrlList", {}).get(
+                    "fullTextUrl", []
+                )
+                if isinstance(full_text_url_list, dict):
+                    full_text_url_list = [full_text_url_list]
+                if not isinstance(full_text_url_list, list):
+                    full_text_url_list = []
+                # Europe PMC search responses expose full-text availability via
+                # fullTextIdList/fullTextUrlList rather than a stable
+                # hasFreeFullText scalar field.
+                has_fulltext = bool(full_text_id_list) or any(
+                    str(url_entry.get("availabilityCode", "")).upper() == "OA"
+                    for url_entry in full_text_url_list
+                    if isinstance(url_entry, dict)
+                )
+                epmc_url = ""
+                if epmc_source and epmc_id:
+                    epmc_url = (
+                        "https://europepmc.org/article/"
+                        f"{quote(epmc_source, safe='')}/{quote(epmc_id, safe='')}"
+                    )
+
+                content = f"Title: {title}\n\nAbstract: {abstract}"
+                metadata = {
+                    "epmcId": epmc_id,
+                    "epmcSource": epmc_source,
+                    "sourceCode": epmc_source,
+                    "title": title,
+                    "authors": authors,
+                    "authorFullNames": author_full_names,
+                    "authorsWithAffiliations": authors_with_affiliations,
+                    "journal": journal,
+                    "year": year,
+                    "pmid": pmid,
+                    "pmcid": pmcid,
+                    "doi": doi,
+                    "source": "Europe PMC",
+                    "url": epmc_url,
+                    "isOpenAccess": is_oa,
+                    "hasPDF": has_pdf,
+                    "inEPMC": in_epmc,
+                    "hasFreeFullText": has_fulltext,
+                    "fullTextIds": full_text_id_list,
+                    "fullTextUrls": full_text_url_list,
+                }
+
+                documents.append(Document(page_content=content, metadata=metadata))
+
+        except (ValueError, KeyError, AttributeError, TypeError) as e:
+            # A malformed response is an upstream failure too — don't disguise it
+            # as an empty result set.
+            raise LiteratureSearchError(
+                f"Europe PMC response could not be parsed: {e}"
+            ) from e
+
+        # Persist to cache for future runs. Outside the guard above: a bad
+        # EPMC_CACHE_TTL_DAYS or a broken cache backend is our failure, not
+        # Europe PMC's, and must not be reported as a search outage.
+        if backend is not None:
+            ttl_days = float(os.environ.get("EPMC_CACHE_TTL_DAYS", "60"))
+            backend.set(key, _documents_to_jsonable(documents), int(ttl_days * 86400))
+
+        return documents
 
 
 def search_scientific_literature_structured(
     query: str, page_size: int = 100
 ) -> List[Dict[str, Any]]:
-    """Search Europe PMC and return up to ``page_size`` structured paper dicts."""
-    params = {
-        "query": query,
-        "format": "json",
-        "pageSize": page_size,
-        "resultType": "core",
-    }
+    """Search scientific literature and return structured results.
 
-    max_attempts = 4
-    for attempt in range(max_attempts):
-        try:
-            response = requests.get(_SEARCH_URL, params=params, timeout=30)
-            response.raise_for_status()
-            break
-        except requests.exceptions.RequestException as exc:
-            status = getattr(getattr(exc, "response", None), "status_code", None)
-            retryable = status in _RETRYABLE_STATUS or isinstance(
-                exc, requests.exceptions.ConnectionError
-            )
-            if attempt < max_attempts - 1 and retryable:
-                time.sleep(2**attempt)
-                continue
-            raise Exception(f"Error performing literature search: {exc}") from exc
+    Args:
+        query: The search query
+        page_size: Number of results to return
 
-    results = response.json().get("resultList", {}).get("result", [])
-    return [_parse_result(r) for r in results]
+    Returns:
+        List of dictionaries containing paper information.
+    """
+    try:
+        base_retriever = EuropePMCRetriever(page_size=page_size)
+        documents = base_retriever.invoke(query)
+
+        # Convert to structured format
+        results = []
+        for doc in documents:
+            metadata = doc.metadata
+            abstract = ""
+            if "Abstract:" in doc.page_content:
+                abstract = doc.page_content.split("Abstract:", 1)[1].strip()
+
+            result = {
+                "title": metadata.get("title", "No title"),
+                "authors": metadata.get("authors", "Unknown authors"),
+                "authorFullNames": metadata.get("authorFullNames", []),
+                "authorsWithAffiliations": metadata.get("authorsWithAffiliations", []),
+                "epmcId": metadata.get("epmcId", ""),
+                "epmcSource": metadata.get("epmcSource", ""),
+                "sourceCode": metadata.get("sourceCode", ""),
+                "pmid": metadata.get("pmid", ""),
+                "pmcid": metadata.get("pmcid", ""),
+                "doi": metadata.get("doi", ""),
+                "source": metadata.get("source", "Europe PMC"),
+                "url": metadata.get("url", ""),
+                "pageContent": doc.page_content,
+                "abstract": abstract,
+                "journal": metadata.get("journal", ""),
+                "year": metadata.get("year", ""),
+                "isOpenAccess": metadata.get("isOpenAccess", False),
+                "hasPDF": metadata.get("hasPDF", False),
+                "inEPMC": metadata.get("inEPMC", False),
+                "hasFreeFullText": metadata.get("hasFreeFullText", False),
+                "fullTextIds": metadata.get("fullTextIds", []),
+                "fullTextUrls": metadata.get("fullTextUrls", []),
+            }
+            results.append(result)
+
+        return results
+
+    except LiteratureSearchError:
+        raise  # already the specific "the search broke" signal
+    except Exception as e:
+        detail = str(e) or repr(e)
+        raise Exception(f"Error performing literature search: {detail}") from e
 
 
 if __name__ == "__main__":
+    # Test block
     import sys
 
-    q = sys.argv[1] if len(sys.argv) > 1 else "Telomere shortening in aging"
-    print(f"Searching Europe PMC for: {q!r}")
-    hits = search_scientific_literature_structured(q, page_size=5)
-    print(f"Found {len(hits)} results:")
-    for i, hit in enumerate(hits, 1):
-        print(f"{i}. {hit['title']} ({hit['year']}) - PMID: {hit['pmid']}")
+    test_query = "Telomere shortening in aging"
+    if len(sys.argv) > 1:
+        test_query = sys.argv[1]
+
+    print(f"Testing EuropePMC search for: '{test_query}'...")
+    try:
+        hits = search_scientific_literature_structured(test_query, page_size=5)
+        print(f"Found {len(hits)} results:")
+        for i, hit in enumerate(hits):
+            print(f"{i + 1}. {hit['title']} ({hit['year']}) - PMID: {hit['pmid']}")
+    except Exception as e:
+        print(f"Search failed: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,20 @@ requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = [
     "requests>=2.31",   # Europe PMC HTTP calls + OpenAI-compatible LLM client
+    "langchain-core>=0.3", # EuropePMCRetriever in literature_search.py
     "bm25s>=0.2",       # BM25 paragraph ranking
     "pysbd>=0.3",       # sentence segmentation for evidence extraction
     "python-dotenv>=1.0", # load LLM_* config from a .env file
     "PyStemmer>=2.2",   # Snowball stemming for BM25 paragraph scoring
     "fastapi>=0.110",   # HTTP orchestrator (orchestrator.py)
     "uvicorn>=0.27",    # ASGI server for the orchestrator
+]
+
+[project.optional-dependencies]
+# Persistent look-aside cache. Optional and imported only when EPMC_CACHE_DIR is
+# set; without it the librarian still runs, it just re-fetches every run.
+cache = [
+    "diskcache>=5.6",   # EPMC_CACHE_DIR — local SQLite cache
 ]
 
 [tool.uv]


### PR DESCRIPTION
## What

`librarian/literature_search.py` is now a **copy of bio-agents' `libs/literature_search.py`**. A `diff` between the two files shows only the Redis backend removal — nothing else. diskcache is kept.

This replaces a local reimplementation of full-text batching that had been written from scratch in this repo, duplicating logic bio-agents already had (`agents/librarian/agent.py:181`, `libs/literature_search.py:285`).

## Why

Keeping the two files identical means fixes flow between the repos without translation. The reimplementation was already missing things upstream had solved:

- **Concurrent full-text fetching** (`fetch_fulltext_many`, 8 shared workers). Fetching one paper at a time was almost all of a Stage-2 thread's wall clock, for work that is pure network wait.
- **`_request_fulltext`'s confirming second request.** Europe PMC intermittently 404s documents that exist — a whole 79-fetch batch was observed 404ing, with every id serving 200 again minutes later. An unconfirmed negative gets cached for days and silently degrades those papers to abstract-only. This was the most valuable thing missing.
- **Negative caching with a shorter TTL** (`EPMC_CACHE_NEGATIVE_TTL_DAYS`, 7d vs 60d), so a paper leaving embargo isn't skipped for two months.
- **`LiteratureSearchError`** — a Europe PMC outage propagates as "the search broke" instead of reaching users as "no literature found".
- **Search-result caching**, and `LITERATURE_EPMC_SYNONYM`.

`Fulltext` replaces the bare-string return, so "this paper has no full text" is distinguishable from "the fetch broke". Only the second is logged; both still fall back to abstract-only.

## agent.py

`_fulltext_pmcid` and `_body_paragraphs` already matched upstream byte-for-byte. The only addition is the `librarian.epmc_fulltext` tracing span emitting `fulltext.count`, as in bio-agents.

## Dependency change

**`langchain-core` becomes a required dependency.** `search_scientific_literature_structured` is built on `EuropePMCRetriever(BaseRetriever)` and returns `Document`s internally. Stripping that out would be exactly the divergence this PR exists to end. `diskcache` is an optional `cache` extra.

## Verified

| Check | Result |
|---|---|
| Diff vs upstream | Redis removal only |
| Live Europe PMC query | 5 real results |
| Search-result cache | 2 calls → 1 request, fields round-trip |
| Full-text cache | 2 batches → 1 request |
| Permanent 404 | fetch + confirm, then served from cache |
| Transient 503 | retried, never cached as final |
| False 404 (404 then 200) | recovers the real XML |
| Concurrency | 8 × 0.2s in 0.20s (sequential: 1.6s) |
| Search outage | raises `LiteratureSearchError` |
| Failed / missing / non-OA full text | paper falls back to abstract-only |

## Notes for review

- `LITERATURE_EPMC_SYNONYM` is documented in the README but is **default-off and set nowhere** in bio-agents either — it came along with the file. Happy to drop the README row; removing the code would be a divergence.
- Anyone with `EPMC_CACHE_TTL_DAYS=0` exported will now silently disable *both* cache layers, not just full text.

## Rebased on main (2026-09-16)

`main` has moved twice since this PR was opened — the TOML runtime config (#22) and the
installable plugin (#23, #24). Both are merged in; the branch is conflict-free again.

The plugin's retrieval step delegates to `agent._paragraphs_for_subquery`
(`skills/librarian/scripts/step2_retrieve.py:86`), so it inherits the concurrent
full-text fetch with no changes of its own.

The earlier "conflicts likely with #19" note is dropped: #19 has been reduced to the
prompt renames, and no longer touches the Stage-2 area.

## One thing this PR does *not* solve, and should be decided alongside it

If bio-agents imports `LibrarianAgent`, retrieval inside librarian runs through
`librarian/literature_search.py` — **a different module object** from
`libs/literature_search.py`, with its own cache backend. The copy here has Redis
removed, so it reads only `EPMC_CACHE_DIR`. In a deployment where
`EPMC_CACHE_REDIS_URL` is the configured backend, **every fetch made through librarian
would be uncached**, while bio-agents' own fetches keep hitting Redis.

That is a property of copying the file, not a defect introduced here — but it decides
whether this PR is the whole answer or the first half of one:

- **copy (this PR)** — librarian works standalone; inside bio-agents there are two code
  paths and two caches.
- **injection seam** — `LibrarianAgent` accepts `search` / `fetch_fulltext_many` from the
  caller, the way it already accepts `tracer=`. bio-agents passes its own, so there is one
  path and one cache. The copy stays the default for standalone use.

The seam does not exist today: the constructor takes no retrieval dependency. It is
additive on top of this PR rather than a competing design, so this can merge either way —
but the decision is worth making before more surface is built on top of retrieval
(cf. the synthesis agent stack, #25–#27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SX5NEK2tMtvHkidz1gQKyj
