### PR TITLE
refactor: load runtime config from a TOML file, injected by the caller

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -264,26 +264,57 @@ The result is a list of passage dicts:
 
 ## ⚙️ Configuration
 
-Defaults live in `librarian/config.py`, and are identical to the settings used in every
-experiment reported in the paper. A few knobs can be overridden via env vars without
-editing code:
+Retrieval knobs live in [`librarian/config.toml`](librarian/config.toml), parsed into
+the frozen `LibrarianRuntimeConfig` dataclass in `librarian/config.py`. The shipped
+values are identical to the settings used in every experiment reported in the paper.
 
-| Env var | Default | Meaning |
+The file is self-contained and every knob is required — there is no fallback and no
+env-var override. A knob missing from the TOML, or a `num_subqueries` below 3, fails
+loudly at load rather than silently defaulting:
+
+| Knob (`config.toml`) | Default | Meaning |
 |---|---|---|
-| `LITERATURE_MAX_QUERY_COUNT` | 7 | max sub-queries generated |
-| `LITERATURE_PAPERS_PER_SUBQUERY` | 50 | Europe PMC results fetched per sub-query |
-| `LITERATURE_PARAGRAPHS_PER_SUBQUERY` | 16 | top-BM25 paragraphs kept per sub-query |
-| `LITERATURE_PARAGRAPHS_PER_JUDGE_BATCH` | 128 | paragraphs per Stage-3 LLM call |
-| `LITERATURE_MAX_PARAGRAPH_WORDS` | 250 | window size before a long paragraph is split |
-| `LITERATURE_PARAGRAPH_OVERLAP_WORDS` | 50 | overlap between adjacent split windows |
-| `LITERATURE_BM25_STEMMING` | on | Snowball stemming for BM25 (`0` to disable) |
-| `LITERATURE_FILTER_TEMPERATURE` | 0.1 | relevance-judge temperature |
-| `LLM_REASONING_EFFORT` | unset | `reasoning_effort` sent on every chat completion (e.g. `low`, `medium`, `high`); omit for models that don't support it |
+| `default_model_name` | `""` | model to request; empty falls back to the `LLM_MODEL` env var |
+| `query_budget_guidance` | see file | planner instructions; `{max_queries}` is filled from `num_subqueries` |
+| `num_subqueries` | 7 | sub-queries the planner generates and runs |
+| `papers_per_subquery` | 50 | Europe PMC results fetched per sub-query |
+| `paragraphs_per_subquery` | 16 | top-BM25 paragraphs kept per sub-query |
+| `paragraphs_per_judge_batch` | 128 | paragraphs per Stage-3 LLM call |
+| `max_paragraph_words` | 250 | window size before a long paragraph is split |
+| `paragraph_overlap_words` | 50 | overlap between adjacent split windows |
+| `filter_temperature` | 0.1 | relevance-judge temperature |
 
-`paragraphs_per_judge_batch` should be `>= paragraphs_per_subquery * max_query_count`
+`paragraphs_per_judge_batch` should be `>= paragraphs_per_subquery * num_subqueries`
 so the whole pool is judged in one call — the judge ranks globally, but results from
 several batches are only concatenated in batch order, so a smaller value silently
 degrades the ranking to per-batch. Raise all three knobs together.
+
+`LibrarianAgent` has no implicit default: the config is a mandatory constructor
+argument, so every caller decides its own.
+
+```python
+from librarian import LibrarianAgent, load_runtime_config
+
+agent = LibrarianAgent(runtime_config=load_runtime_config())
+```
+
+For a one-off change (an ablation sweep, say) don't edit the file — `replace()` the
+loaded config. Validation re-runs, so a sweep is checked exactly like the file is:
+
+```python
+from dataclasses import replace
+
+cfg = replace(load_runtime_config(), num_subqueries=3, papers_per_subquery=20)
+agent = LibrarianAgent(runtime_config=cfg)
+```
+
+Two settings stay outside the config file, since they belong to the process rather than
+to retrieval tuning:
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `LITERATURE_BM25_STEMMING` | on | Snowball stemming for BM25 (`0` to disable) |
+| `LLM_REASONING_EFFORT` | unset | `reasoning_effort` sent on every chat completion (e.g. `low`, `medium`, `high`); omit for models that don't support it |
 
 ---
 
@@ -295,7 +326,8 @@ main.py                        CLI entrypoint
 orchestrator.py                minimal FastAPI server (blocking + SSE endpoints)
 librarian/
   agent.py                     the retrieval pipeline (start here)
-  config.py                    tuning knobs (env-var overridable)
+  config.py                    LibrarianRuntimeConfig + config.toml loader
+  config.toml                  the tuning knobs themselves
   tracing_port.py              TracingPort protocol + no-op default (optional tracer=)
   llm_client.py                minimal OpenAI-compatible client
   literature_search.py         Europe PMC search

--- a/librarian/__init__.py
+++ b/librarian/__init__.py
@@ -6,5 +6,6 @@ of the agent: no tracing, no database, no caching, no Slack — just the flow.
 """
 
 from librarian.agent import LibrarianAgent
+from librarian.config import LibrarianRuntimeConfig, load_runtime_config
 
-__all__ = ["LibrarianAgent"]
+__all__ = ["LibrarianAgent", "LibrarianRuntimeConfig", "load_runtime_config"]

--- a/librarian/agent.py
+++ b/librarian/agent.py
@@ -38,7 +38,7 @@ import bm25s
 import pysbd
 import requests
 
-from librarian.config import load_runtime_config
+from librarian.config import LibrarianRuntimeConfig
 from librarian.jats import extract_body_paragraphs
 from librarian.literature_search import search_scientific_literature_structured
 from librarian.llm_client import create_llm_client, parse_json_response
@@ -485,6 +485,7 @@ class LibrarianAgent:
 
     def __init__(
         self,
+        runtime_config: LibrarianRuntimeConfig,
         full_text_enrichment: bool = True,
         verbose: bool = False,
         llm_base_url: Optional[str] = None,
@@ -493,6 +494,21 @@ class LibrarianAgent:
     ):
         """Build a librarian ready to retrieve evidence for a query.
 
+        :param runtime_config: Tuning knobs (sub-query count, page sizes, filter
+            temperature, ...). Build one with ``config.load_runtime_config()``
+            or a ``dataclasses.replace()`` of it for a one-off override.
+        :type runtime_config: LibrarianRuntimeConfig
+        :param full_text_enrichment: If ``False``, retrieve abstract-only
+            paragraphs instead of fetching open-access full text.
+        :type full_text_enrichment: bool
+        :param verbose: If ``True``, print per-stage progress and debug info.
+        :type verbose: bool
+        :param llm_base_url: Override for the LLM endpoint; falls back to the
+            client's own default resolution when omitted.
+        :type llm_base_url: str or None
+        :param llm_model_name: Override for the LLM model name; falls back to
+            ``runtime_config.default_model_name`` when omitted.
+        :type llm_model_name: str or None
         :param tracer: Span-tracing adapter (see ``tracing_port.py``). Defaults
             to ``NullTracer`` (no-op) — pass your own backend's adapter to
             trace a real run.
@@ -512,20 +528,22 @@ class LibrarianAgent:
         self._filter_done = 0
         self._filter_total = 0
 
+        # Tuning knobs come from the caller-supplied config (see config.py —
+        # load_runtime_config() for the shipped config.toml, or a
+        # dataclasses.replace() of it for a one-off override).
         # Explicit constructor args (llm_model_name) take priority over config.
-        runtime = load_runtime_config()
-        self._max_queries = runtime.max_query_count
-        self._query_budget_guidance = runtime.query_budget_guidance
-        self._papers_per_subquery = runtime.papers_per_subquery
-        self._paragraphs_per_subquery = runtime.paragraphs_per_subquery
-        self._paragraphs_per_judge_batch = runtime.paragraphs_per_judge_batch
-        self._max_paragraph_words = runtime.max_paragraph_words
-        self._paragraph_overlap_words = runtime.paragraph_overlap_words
-        self._filter_temperature = runtime.filter_temperature
+        self._num_subqueries = runtime_config.num_subqueries
+        self._query_budget_guidance = runtime_config.query_budget_guidance
+        self._papers_per_subquery = runtime_config.papers_per_subquery
+        self._paragraphs_per_subquery = runtime_config.paragraphs_per_subquery
+        self._paragraphs_per_judge_batch = runtime_config.paragraphs_per_judge_batch
+        self._max_paragraph_words = runtime_config.max_paragraph_words
+        self._paragraph_overlap_words = runtime_config.paragraph_overlap_words
+        self._filter_temperature = runtime_config.filter_temperature
 
         self.llm = create_llm_client(
             base_url=llm_base_url,
-            model_name=llm_model_name or runtime.default_model_name,
+            model_name=llm_model_name or runtime_config.default_model_name,
         )
         self._query_prompt = _QUERY_PROMPT_PATH.read_text(encoding="utf-8")
         self._filter_prompt = _FILTER_PROMPT_PATH.read_text(encoding="utf-8")
@@ -565,10 +583,16 @@ class LibrarianAgent:
                 f"- {e}" for e in previous_evidences
             )
 
+        # Fill {max_queries} in the budget guidance from the configured cap so the
+        # planner is instructed with the same N we later truncate to — no hardcoded
+        # count in the prompt.
+        budget_guidance = self._query_budget_guidance.replace(
+            "{max_queries}", str(self._num_subqueries)
+        )
         prompt = (
             self._query_prompt.replace("{today_date}", today.isoformat())
             .replace("{today_year}", str(today.year))
-            .replace("{query_budget_guidance}", self._query_budget_guidance)
+            .replace("{query_budget_guidance}", budget_guidance)
             .replace("{conversation}", f"User: {query}")
             .replace("{additional_context}", additional_context)
         )
@@ -624,7 +648,7 @@ class LibrarianAgent:
                 if q and q not in seen:
                     seen.add(q)
                     unique.append(q)
-            result = unique[: self._max_queries]
+            result = unique[: self._num_subqueries]
             self._tracer.set_span_attributes(
                 span,
                 {
@@ -1105,7 +1129,7 @@ class LibrarianAgent:
                 self._paragraphs_for_subquery
             )
             # One CPU-bound thread per sub-query, capped at the CPUs
-            # actually available so a large max_query_count can't
+            # actually available so a large num_subqueries can't
             # oversubscribe a small container.
             stage2_workers = min(max(len(queries), 1), _available_cpus())
             with ThreadPoolExecutor(max_workers=stage2_workers) as pool:

--- a/librarian/config.py
+++ b/librarian/config.py
@@ -1,103 +1,108 @@
-"""Librarian runtime configuration — a single flat set of tuning knobs.
+"""Librarian agent runtime configuration.
 
-The full agent split these between ``config_dev``/``config_prod`` selected by
-``OMNIA_ENV``. This minimal version keeps only the defaults that gave the best
-LitQA2 accuracy, plus the handful of env-var overrides an operator (or an
-ablation sweep) actually needs. Each knob's comment explains what it controls.
+Loaded once via ``load_runtime_config()`` and passed explicitly to
+``LibrarianAgent(runtime_config=...)`` — the constructor has no implicit
+default, so every caller decides its own config.
+
+Values live in ``config.toml`` (this directory), which is self-contained:
+every knob must be set there, there is no fallback.
+
+There is no env-var override mechanism: a one-off change (e.g. an ablation
+sweep varying ``num_subqueries``) is a plain ``dataclasses.replace()`` on the
+loaded config, done explicitly by the caller:
+
+    cfg = replace(load_runtime_config(), num_subqueries=3)
+    LibrarianAgent(runtime_config=cfg, ...)
 """
 
-import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
-# ── Defaults (the winning LitQA2 values) ─────────────────────────────────────
+from mashumaro.mixins.toml import DataClassTOMLMixin
 
-_DEFAULT_MODEL_NAME: Optional[str] = None  # falls back to LLM_MODEL env var
-_DEFAULT_MAX_QUERY_COUNT = 7
-# Europe PMC results fetched per sub-query — every returned paper is decomposed
-# into paragraphs and BM25-ranked, so this is also the per-sub-query recall lever.
-_DEFAULT_PAPERS_PER_SUBQUERY = 50
-# Stage-2 knob k: top-BM25 paragraphs each sub-query passes to Stage 3.
-_DEFAULT_PARAGRAPHS_PER_SUBQUERY = 16
-# Stage-3 batch size: paragraphs per relevance-judge LLM call. Should be
-# >= paragraphs_per_subquery * max_query_count so the whole pool is judged in
-# ONE call: the judge ranks globally, but multi-batch results are merely
-# concatenated in batch order, so a smaller value silently degrades the
-# ranking to per-batch. Raise all three knobs together.
-_DEFAULT_PARAGRAPHS_PER_JUDGE_BATCH = 128
-# Body paragraphs longer than this are split into overlapping windows before
-# BM25 so a long paragraph can't outrank on length alone. Overlap keeps a
-# match that straddles a cut intact.
-_DEFAULT_MAX_PARAGRAPH_WORDS = 250
-_DEFAULT_PARAGRAPH_OVERLAP_WORDS = 50
-# Relevance-filter LLM temperature. 0.1 is the winning config; set to 0 for
-# deterministic, reproducible filtering.
-_DEFAULT_FILTER_TEMPERATURE = 0.1
 
-_DEFAULT_QUERY_BUDGET_GUIDANCE = (
-    "- Generate AT MOST 7 complementary queries.\n"
-    "- Balance recall and precision across the set.\n"
-    "- Include one broader high-recall safety-net query unless the request is "
-    "already extremely specific.\n"
-    "- Use the remaining queries for focused sub-questions, synonyms, or fielded "
-    "variants that improve coverage without over-constraining the search."
-)
+# One query per role in query_budget_guidance: the high-recall safety net plus
+# the focused sub-question/synonym/fielded variants it is balanced against.
+MIN_SUBQUERIES = 3
 
 
 @dataclass(frozen=True)
-class LibrarianRuntimeConfig:
-    """Tuning knobs for the librarian agent (fields map 1:1 to agent constants)."""
+class LibrarianRuntimeConfig(DataClassTOMLMixin):
+    """Tuning knobs for the librarian agent.
 
+    Fields map directly to the constants they replace in ``agent.py``. See
+    each field's comment here for what the knob *is*; see ``config.toml`` for
+    why a given value is what it is.
+
+    No field has a default: build an instance via ``from_toml()`` (see
+    ``load_runtime_config()``) or by passing every argument explicitly.
+    """
+
+    # Model used when llm_model_name isn't passed explicitly to LibrarianAgent.
+    # Empty means the LLM client falls back to the LLM_MODEL env var.
     default_model_name: Optional[str]
+    # {max_queries} is filled at prompt-build time from num_subqueries, so the cap
+    # and the instruction to the planner always agree (one knob drives both).
     query_budget_guidance: str
-    max_query_count: int
+    # ── The four primary sizing knobs ────────────────────────────────────────
+    # How many sub-queries the planner generates and runs. Must be >= MIN_SUBQUERIES
+    # (see __post_init__).
+    num_subqueries: int
+    # Papers Europe PMC returns per sub-query (recall lever, sent as the page size).
     papers_per_subquery: int
+    # Stage 2 knob k: top-BM25 paragraphs each sub-query passes to Stage 3.
     paragraphs_per_subquery: int
+    # Stage 3 batch size: paragraphs per relevance-judge LLM call. Should be
+    # >= paragraphs_per_subquery * num_subqueries so the whole pool is judged
+    # in ONE call: the judge ranks globally, but multi-batch results are
+    # merely concatenated in batch order, so a smaller value silently
+    # degrades the ranking to per-batch. Raise all three knobs together.
     paragraphs_per_judge_batch: int
+    # Body paragraphs longer than this are split into overlapping windows before BM25
+    # so a long paragraph can't outrank on length alone. Overlap keeps a match that
+    # straddles a cut intact.
     max_paragraph_words: int
     paragraph_overlap_words: int
+    # Relevance-filter LLM sampling temperature.
     filter_temperature: float
 
+    def __post_init__(self) -> None:
+        """Reject a sub-query budget too small to cover all the query roles.
 
-def _env_override(name: str, default, cast):
-    """Return ``cast(env[name])`` if the env var is set and valid, else ``default``."""
-    try:
-        return cast(os.environ.get(name, default))
-    except ValueError:
-        return default
+        ``query_budget_guidance`` spends the budget on a broad high-recall
+        safety-net query plus the focused variants that balance it, so a budget
+        below three cannot express the allocation it is handed. Runs on
+        ``from_toml()`` and on ``dataclasses.replace()`` alike, so an ablation
+        sweep is checked the same way the config file is.
+
+        :raises ValueError: if ``num_subqueries`` is below ``MIN_SUBQUERIES``.
+        """
+        if self.num_subqueries < MIN_SUBQUERIES:
+            raise ValueError(
+                f"num_subqueries must be >= {MIN_SUBQUERIES} "
+                f"(one query per role: recall safety net, focused variants), "
+                f"got {self.num_subqueries}."
+            )
+
+
+_CONFIG_DIR = Path(__file__).parent
+_CONFIG_NAME = "config.toml"
 
 
 def load_runtime_config() -> LibrarianRuntimeConfig:
-    """Build the config from the defaults above, applying any ``LITERATURE_*``
-    env-var overrides for the operator-tunable knobs."""
-    return LibrarianRuntimeConfig(
-        default_model_name=_DEFAULT_MODEL_NAME,
-        query_budget_guidance=_DEFAULT_QUERY_BUDGET_GUIDANCE,
-        max_query_count=_env_override(
-            "LITERATURE_MAX_QUERY_COUNT", _DEFAULT_MAX_QUERY_COUNT, int
-        ),
-        papers_per_subquery=_env_override(
-            "LITERATURE_PAPERS_PER_SUBQUERY", _DEFAULT_PAPERS_PER_SUBQUERY, int
-        ),
-        paragraphs_per_subquery=_env_override(
-            "LITERATURE_PARAGRAPHS_PER_SUBQUERY",
-            _DEFAULT_PARAGRAPHS_PER_SUBQUERY,
-            int,
-        ),
-        paragraphs_per_judge_batch=_env_override(
-            "LITERATURE_PARAGRAPHS_PER_JUDGE_BATCH",
-            _DEFAULT_PARAGRAPHS_PER_JUDGE_BATCH,
-            int,
-        ),
-        max_paragraph_words=_env_override(
-            "LITERATURE_MAX_PARAGRAPH_WORDS", _DEFAULT_MAX_PARAGRAPH_WORDS, int
-        ),
-        paragraph_overlap_words=_env_override(
-            "LITERATURE_PARAGRAPH_OVERLAP_WORDS",
-            _DEFAULT_PARAGRAPH_OVERLAP_WORDS,
-            int,
-        ),
-        filter_temperature=_env_override(
-            "LITERATURE_FILTER_TEMPERATURE", _DEFAULT_FILTER_TEMPERATURE, float
-        ),
-    )
+    """Return the ``LibrarianRuntimeConfig`` read from ``config.toml``.
+
+    Fails loudly rather than silently substituting a default — a knob missing
+    from the file is an error, not an invitation to guess.
+
+    :return: The runtime config.
+    :rtype: LibrarianRuntimeConfig
+    :raises FileNotFoundError: if ``config.toml`` is missing.
+    :raises mashumaro.exceptions.MissingField: if the TOML file is missing a
+        required knob.
+    :raises ValueError: if the TOML file sets ``num_subqueries`` below
+        ``MIN_SUBQUERIES``.
+    """
+    toml_path = _CONFIG_DIR / _CONFIG_NAME
+    return LibrarianRuntimeConfig.from_toml(toml_path.read_text(encoding="utf-8"))

--- a/librarian/config.toml
+++ b/librarian/config.toml
@@ -1,0 +1,40 @@
+# Librarian runtime configuration.
+#
+# Self-contained: every knob the agent reads must be set here, there is no
+# fallback and no env-var override. Schema + what each knob means:
+# LibrarianRuntimeConfig in config.py. Comments in this file explain only why
+# these values are what they are.
+#
+# The values below are the ones that produced the LitQA2 accuracy reported in
+# the README — change them only if you intend to change retrieval behaviour.
+# For a one-off change (an ablation sweep, say), don't edit this file: use
+# dataclasses.replace() on the loaded config (see config.py).
+
+# Model requested when llm_model_name isn't passed to LibrarianAgent.
+# Empty means "no opinion": the LLM client falls back to the LLM_MODEL env var,
+# which is how this open-source build is normally pointed at a backend.
+default_model_name = ""
+
+# {max_queries} is filled at prompt-build time from num_subqueries, so the cap
+# and the instruction to the planner always agree (one knob drives both).
+query_budget_guidance = """
+- Generate AT MOST {max_queries} complementary queries.
+- Balance recall and precision across the set.
+- Include one broader high-recall safety-net query unless the request is already extremely specific.
+- Use the remaining queries for focused sub-questions, synonyms, or fielded variants that improve coverage without over-constraining the search."""
+
+# 7 sub-queries: the Stage-2 fan-out runs one search+BM25 thread per sub-query,
+# sized to the CPUs actually available (see _available_cpus in agent.py).
+num_subqueries = 7
+# 50 × 7 = 350 raw papers pooled across sub-queries. Every returned paper is
+# decomposed into paragraphs and BM25-ranked, so this is also the per-sub-query
+# recall lever.
+papers_per_subquery = 50
+paragraphs_per_subquery = 16
+# 16 × 7 = 112 ≤ 128 — the whole pool is judged in one call (see config.py).
+paragraphs_per_judge_batch = 128
+
+max_paragraph_words = 250
+paragraph_overlap_words = 50
+# 0.1 is the winning LitQA2 config; use 0 for deterministic, reproducible filtering.
+filter_temperature = 0.1

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ import sys
 
 from dotenv import load_dotenv
 
-from librarian import LibrarianAgent
+from librarian import LibrarianAgent, load_runtime_config
 from librarian.progress import Spinner
 
 # Load LLM_BASE_URL / LLM_MODEL / LLM_API_KEY from a .env file if present.
@@ -29,7 +29,11 @@ def main() -> None:
     # On a terminal, show a live spinner and keep the agent's own logs quiet so
     # they don't fight the spinner. When piped/redirected, fall back to plain logs.
     interactive = sys.stderr.isatty()
-    agent = LibrarianAgent(verbose=not interactive)
+    # Tuning knobs come from librarian/config.toml; edit that file to change
+    # them, or dataclasses.replace() the loaded config for a one-off run.
+    agent = LibrarianAgent(
+        runtime_config=load_runtime_config(), verbose=not interactive
+    )
     if interactive:
         with Spinner() as spinner:
             passages = agent.run(query, on_progress=spinner.update)

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -25,12 +25,16 @@ from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
-from librarian import LibrarianAgent
+from librarian import LibrarianAgent, load_runtime_config
 
 # Same as main.py: pick up LLM_BASE_URL / LLM_MODEL / LLM_API_KEY from a .env file.
 load_dotenv()
 
 app = FastAPI(title="Librarian Orchestrator")
+
+# Read the tuning knobs once, at import: a malformed librarian/config.toml
+# should fail the process at startup, not the first request.
+RUNTIME_CONFIG = load_runtime_config()
 
 
 class RunRequest(BaseModel):
@@ -56,7 +60,10 @@ def _run(
     # ponytail: a fresh agent per request. Construction just reads two prompt
     # files and builds an HTTP client; cache it in a module global if profiling
     # ever says otherwise.
-    agent = LibrarianAgent(full_text_enrichment=request.full_text_enrichment)
+    agent = LibrarianAgent(
+        runtime_config=RUNTIME_CONFIG,
+        full_text_enrichment=request.full_text_enrichment,
+    )
     papers = agent.run(request.query, on_progress=on_progress)
     return {
         "query": request.query,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pysbd>=0.3",       # sentence segmentation for evidence extraction
     "python-dotenv>=1.0", # load LLM_* config from a .env file
     "PyStemmer>=2.2",   # Snowball stemming for BM25 paragraph scoring
+    "mashumaro[toml]>=3.22", # dataclass <-> TOML parsing for librarian/config.toml
     "fastapi>=0.110",   # HTTP orchestrator (orchestrator.py)
     "uvicorn>=0.27",    # ASGI server for the orchestrator
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -163,7 +163,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -211,6 +211,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "bm25s" },
     { name = "fastapi" },
+    { name = "mashumaro", extra = ["toml"] },
     { name = "pysbd" },
     { name = "pystemmer" },
     { name = "python-dotenv" },
@@ -222,11 +223,30 @@ dependencies = [
 requires-dist = [
     { name = "bm25s", specifier = ">=0.2" },
     { name = "fastapi", specifier = ">=0.110" },
+    { name = "mashumaro", extras = ["toml"], specifier = ">=3.22" },
     { name = "pysbd", specifier = ">=0.3" },
     { name = "pystemmer", specifier = ">=2.2" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "requests", specifier = ">=2.31" },
     { name = "uvicorn", specifier = ">=0.27" },
+]
+
+[[package]]
+name = "mashumaro"
+version = "3.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/e3/a06dcd2e6df094c5e294721926f1f76da30f50823e2ac233a9198e804891/mashumaro-3.22.tar.gz", hash = "sha256:64538cc365204402a060ebde683a86505b5a4344acf6870d79021e9fbfe57360", size = 197845, upload-time = "2026-05-26T14:39:21.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/1c/92fd926c2e7763535454683250dbdd8d10aa2f2c62f58d6abbcce4d8b3fc/mashumaro-3.22-py3-none-any.whl", hash = "sha256:17dc4d7294c33ef380a8b929dda0608577aa2141988c00a0c4932310108fe71d", size = 95916, upload-time = "2026-05-26T14:39:20.233Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli-w" },
 ]
 
 [[package]]
@@ -666,6 +686,69 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Aligns this repo's config handling with the internal bio-agents librarian, which is the blueprint for this build.

## What changed

| | before | after |
|---|---|---|
| Source of values | Python constants in `config.py` | `librarian/config.toml` |
| Parsing | — | `mashumaro` `DataClassTOMLMixin.from_toml()` |
| Env overrides | `LITERATURE_*` per knob | none — removed by design |
| Injection | agent called `load_runtime_config()` itself | mandatory `LibrarianAgent(runtime_config=...)` |
| One-off overrides | set env vars before construction | `dataclasses.replace()` |
| Validation | none | `num_subqueries >= MIN_SUBQUERIES` (3), on load *and* on `replace()` |
| Missing knob | impossible (defaults baked in) | `MissingField` at load |

## Two knock-on fixes

- `max_query_count` is renamed `num_subqueries`, matching the field it mirrors.
- **`{max_queries}` is now substituted into the planner prompt.** The guidance string hardcoded `AT MOST 7` while the count knob drove only the post-hoc truncation `unique[: self._max_queries]` — so raising the knob still asked the planner for 7, and lowering it asked for 7 and then discarded the extras. The cap and the instruction are now one knob. At the shipped `num_subqueries = 7` the rendered prompt is byte-identical to before, so this is behaviour-neutral today.

`LITERATURE_BM25_STEMMING` and `LLM_REASONING_EFFORT` stay env vars: they belong to the process rather than to retrieval tuning, and sit outside the config dataclass upstream too.

## Deliberate deviations from the blueprint

1. **One `config.toml`, no `OMNIA_ENV`.** Upstream's `config_dev`/`config_prod` split serves two deployments with different models and context windows; this repo ships one set of values, so a split would have meant inventing a second environment. `_CONFIG_DIR` stays module-level and monkeypatchable if that changes.
2. **`load_runtime_config()`**, not upstream's `load_librarian_runtime_config()` — the prefix disambiguates among several agents over there; here the module is already `librarian.config`.
3. **`default_model_name = ""`.** Every field is required and TOML can't express `None`; the empty string is falsy, so it flows through the client's existing `LLM_MODEL` fallback, which is how this build is normally pointed at a backend.
4. **Kept this repo's `query_budget_guidance` text**, only swapping the hardcoded `7` for `{max_queries}`. Upstream's recall/coverage/precision role-split text would change what the planner emits, and the README ties these defaults to the published benchmark numbers.
5. **`MIN_SUBQUERIES = 3` kept, rationale reworded** to match this repo's guidance text (safety-net query plus the focused variants balanced against it) rather than upstream's three-role split.

## Testing

No test suite in this repo yet, so verified by hand in the venv:

- config loads; `replace()` works and re-validates (`num_subqueries=1` → `ValueError`)
- `LibrarianAgent()` without a config → `TypeError`
- a TOML missing a knob → `MissingField`
- rendered planner prompt contains `AT MOST 7`, no leftover `{max_queries}`
- `main.py` and `orchestrator.py` both import and construct cleanly

Happy to port upstream's `tests/test_config.py` in a follow-up — it would be the first test here, so it brings pytest along with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
